### PR TITLE
make monitor group `description` param to be optional

### DIFF
--- a/site24x7/monitor_group.go
+++ b/site24x7/monitor_group.go
@@ -14,7 +14,7 @@ var MonitorGroupSchema = map[string]*schema.Schema{
 	},
 	"description": {
 		Type:        schema.TypeString,
-		Required:    true,
+		Optional:    true,
 		Description: "Description for the Monitor Group.",
 	},
 	// As of now we don't support associating monitors via configuration file


### PR DESCRIPTION
As it's declared in the API specifications: https://www.site24x7.com/help/api/#monitor-groups