### PR TITLE
Fix monitor

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 terraform {
   # Require Terraform version 0.15.x (recommended)
-  required_version = "~> 0.15.0"
+  required_version = "> 0.15.0"
 
   required_providers {
     site24x7 = {

--- a/main.tf
+++ b/main.tf
@@ -92,10 +92,10 @@ resource "site24x7_website_monitor" "website_monitor_example" {
 // DNS Server API doc: https://www.site24x7.com/help/api/#dns-server
 resource "site24x7_dns_server_monitor" "dns_monitor_basic" {
   // (Required) Name for the monitor.
-  display_name                  = "Nowatt basic DNS monitor - Terraform"
+  display_name              = "Nowatt basic DNS monitor - Terraform"
 
   // (Required) DNS Name Server to be monitored
-  dns_host               = "185.43.51.84"
+  dns_host                  = "185.43.51.84"
 
   // (Required) Domain name to be resolved.
   domain_name               = "www.nowatt.com"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 terraform {
   # Require Terraform version 0.15.x (recommended)
-  required_version = "> 0.15.0"
+  required_version = "~> 0.15.0"
 
   required_providers {
     site24x7 = {
@@ -92,13 +92,13 @@ resource "site24x7_website_monitor" "website_monitor_example" {
 // DNS Server API doc: https://www.site24x7.com/help/api/#dns-server
 resource "site24x7_dns_server_monitor" "dns_monitor_basic" {
   // (Required) Name for the monitor.
-  display_name              = "Nowatt basic DNS monitor - Terraform"
+  display_name = "Nowatt basic DNS monitor - Terraform"
 
   // (Required) DNS Name Server to be monitored
-  dns_host                  = "185.43.51.84"
+  dns_host = "185.43.51.84"
 
   // (Required) Domain name to be resolved.
-  domain_name               = "www.nowatt.com"
+  domain_name = "www.nowatt.com"
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -92,13 +92,13 @@ resource "site24x7_website_monitor" "website_monitor_example" {
 // DNS Server API doc: https://www.site24x7.com/help/api/#dns-server
 resource "site24x7_dns_server_monitor" "dns_monitor_basic" {
   // (Required) Name for the monitor.
-  display_name = "Nowatt basic DNS monitor - Terraform"
+  display_name                  = "Nowatt basic DNS monitor - Terraform"
 
   // (Required) DNS Name Server to be monitored
-  dns_host = "185.43.51.84"
+  dns_host               = "185.43.51.84"
 
   // (Required) Domain name to be resolved.
-  domain_name = "www.nowatt.com"
+  domain_name               = "www.nowatt.com"
 }
 
 

--- a/site24x7/monitors/website.go
+++ b/site24x7/monitors/website.go
@@ -284,7 +284,7 @@ var websiteMonitorSchema = map[string]*schema.Schema{
 		Description: "Threshold profile to be associated with the monitor.",
 	},
 	"monitor_groups": {
-		Type: schema.TypeList,
+		Type: schema.TypeSet,
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
 		},
@@ -565,7 +565,7 @@ func resourceDataToWebsiteMonitor(d *schema.ResourceData, client site24x7.Client
 	}
 
 	var monitorGroups []string
-	for _, group := range d.Get("monitor_groups").([]interface{}) {
+	for _, group := range d.Get("monitor_groups").(*schema.Set).List() {
 		if group != nil {
 			monitorGroups = append(monitorGroups, group.(string))
 		}


### PR DESCRIPTION
In website monitor we see the website monitor being updated with every terraform run even though there are no changes being made to the monitor at all. 

The cause is due to the order of the monitor group in the list. If the order changes for the monitor group id's then the website monitor gets update even though there are no new updates in the terraform file 

e.g
```bash
 resource "site24x7_website_monitor" "url_monitor" {
             id                          = "12340000123456"
           ~ monitor_groups              = [
               - "12340000246578",
                 "12342232424",
               + "12340000246578",
             ]
             # (31 unchanged attributes hidden)
         }
```