### PR TITLE
Add Canada to DataCenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ provider "site24x7" {
   oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
 
   // (Required) Specify the data center from which you have obtained your
-  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
   data_center = "US"
 
   // (Optional) The access token will be looked up in the SITE24X7_OAUTH2_ACCESS_TOKEN

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ provider "site24x7" {
   zaaid = "1234"
 
   // (Required) Specify the data center from which you have obtained your
-  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
   data_center = "US"
   
   // (Optional) The minimum time to wait in seconds before retrying failed Site24x7 API requests.
@@ -105,7 +105,7 @@ resource "site24x7_website_monitor" "website_monitor_example" {
 | `oauth2_client_id`     | String  | Required  | Client ID obtained during Client Registration. The `SITE24X7_OAUTH2_CLIENT_ID` environment variable can also be used.                                                       |
 | `oauth2_client_secret` | String  | Required  | Client Secret obtained during Client Registration. The `SITE24X7_OAUTH2_CLIENT_SECRET` environment variable can also be used.                                               |
 | `oauth2_refresh_token` | String  | Required  | Refresh Token using which a new access token has to be generated. The `SITE24X7_OAUTH2_REFRESH_TOKEN` environment variable can also be used.                                |
-| `data_center`          | String  | Required  | The region for the data center from which OAuth 2.0 client credentials and refresh token were generated. Valid values are `US` or `EU` or `AU` or `IN` or `CN` or `JP`.     |
+| `data_center`          | String  | Required  | The region for the data center from which OAuth 2.0 client credentials and refresh token were generated. Valid values are `US` or `EU` or `AU` or `IN` or `CN` or `JP` or `CA`.     |
 | `oauth2_access_token`  | String  | Optional  | The access token generated using the refresh token. The `SITE24X7_OAUTH2_ACCESS_TOKEN` environment variable can also be used.                                               |
 | `access_token_expiry`  | String  | Optional  | `oauth2_access_token` expiry in seconds. Specify access_token_expiry when `oauth2_access_token` is configured.                                                              |
 | `zaaid`                | String  | Optional  | ZAAID of the customer under a MSP or BU.                                                                                                                                    |

--- a/examples/amazon_monitor_us.tf
+++ b/examples/amazon_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/bulk_resource_addition_us.tf
+++ b/examples/bulk_resource_addition_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/connectwise_integration_us.tf
+++ b/examples/connectwise_integration_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/credential_profiles_us.tf
+++ b/examples/credential_profiles_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
   # zaaid = "1234"
 
   // (Required) Specify the data center from which you have obtained your
-  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
   data_center = "US"
 
   // The minimum time to wait in seconds before retrying failed Site24x7 API requests.

--- a/examples/data-sources/aws_external_id_data_source_us.tf
+++ b/examples/data-sources/aws_external_id_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/data-sources/credential_profile_data_source_us.tf
+++ b/examples/data-sources/credential_profile_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/data-sources/device_key_data_source_us.tf
+++ b/examples/data-sources/device_key_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/data-sources/it_automation_data_source_us.tf
+++ b/examples/data-sources/it_automation_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/data-sources/location_profile_data_source_us.tf
+++ b/examples/data-sources/location_profile_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/data-sources/monitor_data_source_us.tf
+++ b/examples/data-sources/monitor_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/data-sources/monitor_group_data_source_us.tf
+++ b/examples/data-sources/monitor_group_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/data-sources/monitors_data_source_us.tf
+++ b/examples/data-sources/monitors_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/data-sources/msp_data_source_us.tf
+++ b/examples/data-sources/msp_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/data-sources/notification_profile_data_source_us.tf
+++ b/examples/data-sources/notification_profile_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/data-sources/subgroup_data_source_us.tf
+++ b/examples/data-sources/subgroup_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/data-sources/tag_data_source_us.tf
+++ b/examples/data-sources/tag_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/data-sources/threshold_profile_data_source_us.tf
+++ b/examples/data-sources/threshold_profile_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/data-sources/user_group_data_source_us.tf
+++ b/examples/data-sources/user_group_data_source_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/dns_server_monitor_us.tf
+++ b/examples/dns_server_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/domain_expiry_monitor_us.tf
+++ b/examples/domain_expiry_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/ftp_transfer_monitor_us.tf
+++ b/examples/ftp_transfer_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/heartbeat_monitor_us.tf
+++ b/examples/heartbeat_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/import/tags_import_us.tf
+++ b/examples/import/tags_import_us.tf
@@ -38,7 +38,7 @@ provider "site24x7" {
   # zaaid = "1234"
 
   // (Required) Specify the data center from which you have obtained your
-  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
   data_center = "US"
 
   // (Optional) The minimum time to wait in seconds before retrying failed Site24x7 API requests.

--- a/examples/isp_monitor_us.tf
+++ b/examples/isp_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/location_profile_us.tf
+++ b/examples/location_profile_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/monitor_group_us.tf
+++ b/examples/monitor_group_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/notification_profile_us.tf
+++ b/examples/notification_profile_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/opsgenie_integration_us.tf
+++ b/examples/opsgenie_integration_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/pagerduty_integration_us.tf
+++ b/examples/pagerduty_integration_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/ping_monitor_us.tf
+++ b/examples/ping_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/port_monitor_us.tf
+++ b/examples/port_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/rest_api_monitor_us.tf
+++ b/examples/rest_api_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
   # zaaid = "1234"
 
   // (Required) Specify the data center from which you have obtained your
-  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
   data_center = "US"
 
   // The minimum time to wait in seconds before retrying failed Site24x7 API requests.

--- a/examples/rest_api_transaction_monitor_us.tf
+++ b/examples/rest_api_transaction_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
   zaaid = "1234"
 
   // (Required) Specify the data center from which you have obtained your
-  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
   data_center = "US"
 
   // The minimum time to wait in seconds before retrying failed Site24x7 API requests.

--- a/examples/schedule_maintenance_us.tf
+++ b/examples/schedule_maintenance_us.tf
@@ -26,7 +26,7 @@ provider "site24x7" {
   oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
 
   // (Required) Specify the data center from which you have obtained your
-  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
   data_center = "US"
 
   // (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/server_agent_installation_GCP.tf
+++ b/examples/server_agent_installation_GCP.tf
@@ -30,7 +30,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/server_agent_installation_azure.tf
+++ b/examples/server_agent_installation_azure.tf
@@ -31,7 +31,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/server_monitor_us.tf
+++ b/examples/server_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/servicenow_integration_us.tf
+++ b/examples/servicenow_integration_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/slack_integration_us.tf
+++ b/examples/slack_integration_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/ssl_monitor_us.tf
+++ b/examples/ssl_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/subgroup_us.tf
+++ b/examples/subgroup_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/tag_us.tf
+++ b/examples/tag_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/telegram_integration_us.tf
+++ b/examples/telegram_integration_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
   oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
 
   // (Required) Specify the data center from which you have obtained your
-  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
   data_center = "US"
 
   // (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/threshold_profile_us.tf
+++ b/examples/threshold_profile_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
   # zaaid = "1234"
 
   // (Required) Specify the data center from which you have obtained your
-  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
   data_center = "US"
 
   // The minimum time to wait in seconds before retrying failed Site24x7 API requests.

--- a/examples/url_it_automation_action_us.tf
+++ b/examples/url_it_automation_action_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/user_group_us.tf
+++ b/examples/user_group_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/user_us.tf
+++ b/examples/user_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/web_page_speed_monitor_us.tf
+++ b/examples/web_page_speed_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
   oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
 
   // (Required) Specify the data center from which you have obtained your
-  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
   data_center = "US"
 
   // (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/web_transaction_browser_monitor_us.tf
+++ b/examples/web_transaction_browser_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/webhook_integration_us.tf
+++ b/examples/webhook_integration_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/examples/website_monitor_us.tf
+++ b/examples/website_monitor_us.tf
@@ -29,7 +29,7 @@ provider "site24x7" {
 	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
   
 	// (Required) Specify the data center from which you have obtained your
-	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
 	data_center = "US"
 	
 	// (Optional) ZAAID of the customer under a MSP or BU

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ provider "site24x7" {
   # zaaid = "1234"
 
   // (Required) Specify the data center from which you have obtained your
-  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
   data_center = "US"
 
   // (Optional) The minimum time to wait in seconds before retrying failed Site24x7 API requests.

--- a/site24x7/data_center.go
+++ b/site24x7/data_center.go
@@ -37,6 +37,12 @@ var dataCenter = map[string]DataCenter{
 		site24x7APIBaseURL:   "https://www.site24x7.jp//api",
 		zohoAccountsTokenURL: "https://accounts.zoho.jp/oauth/v2/token",
 	},
+	"CA": {
+		displayName:          "Canada",
+		code:                 "CA",
+		site24x7APIBaseURL:   "https://www.site24x7.ca/api",
+		zohoAccountsTokenURL: "https://accounts.zohocloud.ca/oauth/v2/token",
+	},
 }
 
 type DataCenter struct {

--- a/utilities/importer/empty_configuration.tf
+++ b/utilities/importer/empty_configuration.tf
@@ -30,7 +30,7 @@ provider "site24x7" {
   # zaaid = "1234"
 
   // (Required) Specify the data center from which you have obtained your
-  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP).
+  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
   data_center = "US"
 
   // The minimum time to wait in seconds before retrying failed Site24x7 API requests.


### PR DESCRIPTION
Hi, 

Our team and I require support for the Canadian datacenter in your Terraform provider. I’ve already forked the project, and if you’re interested, we’d like to discuss merging this feature.

As of today, we added the below changes to `site24x7/data_center.go`.

```go
package site24x7

var dataCenter = map[string]DataCenter{
...
	"CA": {
		displayName:          "Canada",
		code:                 "CA",
		site24x7APIBaseURL:   "https://www.site24x7.ca/api",
		zohoAccountsTokenURL: "https://accounts.zohocloud.ca/oauth/v2/token",
	},
}
```

We’ve made changes to the documentation in multiple locations where we previously mentioned `(US/EU/…)` to now include `(US/EU/…/CA)`. Additionally, we’ve updated the docs/index.md file to reflect the new provider documentation.

Let us know if there are any missing changes.

Thanks !