### PR TITLE
User data source support in site24x7 Terraform 

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -1,0 +1,90 @@
+---
+layout: "site24x7"
+page_title: "Site24x7: site24x7_user"
+sidebar_current: "docs-site24x7-data-source-user"
+description: |-
+  Get information about a user  in Site24x7.
+---
+
+# Data Source: site24x7\_user
+
+Use this data source to retrieve information about an existing user in Site24x7.
+
+## Example Usage
+
+```hcl
+
+// Data source to fetch a user
+data "site24x7_user" "s247user" {
+  // (Required) Regular expression denoting the name of the user.
+  name_regex = "vinoth"  
+}
+
+// Displays the User ID
+output "s247_user_id" {
+  description = "User ID : "
+  value       = data.site24x7_user.s247user.id
+}
+
+// Displays the User ID
+output "s247_user_email" {
+  description = "Email : "
+  value       = data.site24x7_user.s247user.email
+}
+
+// Displays the User Role
+output "s247_user_displayname" {
+  description = "Display_Name : "
+  value       = data.site24x7_user.s247user.display_name
+}
+
+// Displays the matched userIDS
+output "s247_user_matchingUserIDs" {
+  description = "Role : "
+  value       = data.site24x7_user.s247user.matching_ids
+}
+
+// Displays the matched IDs and Names 
+
+output "s247_user_matchingUserIDsAndNames" {
+  description = "Role : "
+  value       = data.site24x7_user.s247user.matching_ids_and_names
+}
+//
+
+// Iterating the user group data source
+data "site24x7_user" "userlist" {
+  for_each = toset(["e", "a"])
+  name_regex = each.key
+}
+
+locals {
+  user_group_ids = toset([for prof in data.site24x7_user.userlist : prof.id])
+  user_group_names = toset([for prof in data.site24x7_user.userlist : prof.display_name])
+}
+
+output "s247_user_ids" {
+  description = "Matching user IDs : "
+  value       = local.user_group_ids
+}
+
+output "s247_user_names" {
+  description = "Matching user names : "
+  value       = local.user_names
+}
+
+```
+
+## Attributes Reference
+
+### Required
+
+* `name_regex` (String) Regular expression denoting the name of the user.
+
+### Read-Only
+
+* `id` (String) The ID of this resource.
+* `matching_ids` (List) List of user  IDs matching the `name_regex`.
+* `matching_ids_and_names` (List) List of user  IDs and names matching the `name_regex`.
+* `display_name` (String) Display name for the user.
+* `email` (String) Email address of the user.

--- a/examples/data-sources/user_data_source_us.tf
+++ b/examples/data-sources/user_data_source_us.tf
@@ -48,19 +48,19 @@ provider "site24x7" {
   }
 
 
-// Data source to fetch a user group
+// Data source to fetch a user
 data "site24x7_user" "s247user" {
-  // (Required) Regular expression denoting the name of the user group.
+  // (Required) Regular expression denoting the name of the user.
   name_regex = "vinoth"  
 }
 
-// Displays the User Group ID
+// Displays the User ID
 output "s247_user_id" {
-  description = "User group ID : "
+  description = "User ID : "
   value       = data.site24x7_user.s247user.id
 }
 
-// Displays the User Group ID
+// Displays the User ID
 output "s247_user_email" {
   description = "Email : "
   value       = data.site24x7_user.s247user.email
@@ -72,11 +72,13 @@ output "s247_user_displayname" {
   value       = data.site24x7_user.s247user.display_name
 }
 
-// Displays the User Role
+// Displays the matched userIDS
 output "s247_user_matchingUserIDs" {
   description = "Role : "
   value       = data.site24x7_user.s247user.matching_ids
 }
+
+// Displays the matched IDs and Names 
 
 output "s247_user_matchingUserIDsAndNames" {
   description = "Role : "

--- a/examples/data-sources/user_data_source_us.tf
+++ b/examples/data-sources/user_data_source_us.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     site24x7 = {
       source  = "site24x7/site24x7"
+      //version = "1.0.92"
       # Update the latest version from https://registry.terraform.io/providers/site24x7/site24x7/latest 
       
     }
   }
 }
-
 // Authentication API doc - https://www.site24x7.com/help/api/#authentication
 provider "site24x7" {
   // (Security recommendation - It is always best practice to store your credentials in a Vault of your choice.)
@@ -47,72 +47,39 @@ provider "site24x7" {
   
   }
 
+
 // Data source to fetch a user group
-data "site24x7_user_group" "s247usergroup" {
+data "site24x7_user" "s247user" {
   // (Required) Regular expression denoting the name of the user group.
-  name_regex = "a"
-  
+  name_regex = "vinoth"  
 }
 
 // Displays the User Group ID
-output "s247_user_group_id" {
+output "s247_user_id" {
   description = "User group ID : "
-  value       = data.site24x7_user_group.s247usergroup.id
+  value       = data.site24x7_user.s247user.id
 }
 
-// Displays the User Group Name
-output "s247_user_group_name" {
-  description = "User group name : "
-  value       = data.site24x7_user_group.s247usergroup.display_name
+// Displays the User Group ID
+output "s247_user_email" {
+  description = "Email : "
+  value       = data.site24x7_user.s247user.email
 }
 
-// Displays the matching usergroup IDs
-output "s247_matching_ids" {
-  description = "Matching user group IDs : "
-  value       = data.site24x7_user_group.s247usergroup.matching_ids
+// Displays the User Role
+output "s247_user_displayname" {
+  description = "Display_Name : "
+  value       = data.site24x7_user.s247user.display_name
 }
 
-// Displays the matching usergroup IDs and names
-output "s247_matching_ids_and_names" {
-  description = "Matching user group IDs and names : "
-  value       = data.site24x7_user_group.s247usergroup.matching_ids_and_names
+// Displays the User Role
+output "s247_user_matchingUserIDs" {
+  description = "Role : "
+  value       = data.site24x7_user.s247user.matching_ids
 }
 
-// Displays the Users
-output "s247_usergroup_users" {
-  description = "Users : "
-  value       = data.site24x7_user_group.s247usergroup.users
+output "s247_user_matchingUserIDsAndNames" {
+  description = "Role : "
+  value       = data.site24x7_user.s247user.matching_ids_and_names
 }
-
-// Displays the attribute group ID
-output "s247_attribute_group_id" {
-  description = "Attribute group ID : "
-  value       = data.site24x7_user_group.s247usergroup.attribute_group_id
-}
-
-// Displays the product ID
-output "s247_product_id" {
-  description = "Product ID : "
-  value       = data.site24x7_user_group.s247usergroup.product_id
-}
-
-// Iterating the user group data source
-data "site24x7_user_group" "usergrouplist" {
-  for_each = toset(["e", "a"])
-  name_regex = each.key
-}
-
-locals {
-  user_group_ids = toset([for prof in data.site24x7_user_group.usergrouplist : prof.id])
-  user_group_names = toset([for prof in data.site24x7_user_group.usergrouplist : prof.display_name])
-}
-
-output "s247_user_group_ids" {
-  description = "Matching user group IDs : "
-  value       = local.user_group_ids
-}
-
-output "s247_user_group_names" {
-  description = "Matching user group names : "
-  value       = local.user_group_names
-}
+//

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 terraform {
   # Require Terraform version 0.15.x (recommended)
-  required_version = "~> 0.15.0"
 
   required_providers {
     site24x7 = {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -122,6 +122,7 @@ func Provider() terraform.ResourceProvider {
 			"site24x7_monitor_group":        site24x7.DataSourceSite24x7MonitorGroup(),
 			// "site24x7_subgroup":             site24x7.DataSourceSite24x7Subgroup(),
 			"site24x7_user_group":         site24x7.DataSourceSite24x7UserGroup(),
+			"site24x7_user":               site24x7.DataSourceSite24x7User(),
 			"site24x7_it_automation":      site24x7.DataSourceSite24x7ITAutomation(),
 			"site24x7_tag":                site24x7.DataSourceSite24x7Tag(),
 			"site24x7_msp":                site24x7.DataSourceSite24x7MSP(),

--- a/site24x7/user_data_source.go
+++ b/site24x7/user_data_source.go
@@ -1,0 +1,101 @@
+package site24x7
+
+import (
+	"errors"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/site24x7/terraform-provider-site24x7/api"
+)
+
+var userDataSourceSchema = map[string]*schema.Schema{
+	"name_regex": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Regular expression denoting the name of the user.",
+	},
+	"matching_ids": {
+		Type:        schema.TypeList,
+		Computed:    true,
+		Elem:        &schema.Schema{Type: schema.TypeString},
+		Description: "List of user IDs matching the name_regex.",
+	},
+	"matching_ids_and_names": {
+		Type:        schema.TypeList,
+		Computed:    true,
+		Elem:        &schema.Schema{Type: schema.TypeString},
+		Description: "List of user IDs and names matching the name_regex.",
+	},
+	"display_name": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Display name for the user.",
+	},
+	"email": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Email address of the user.",
+	},
+	"role": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Role assigned to the user.",
+	},
+	"status": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Status of the user (active or inactive).",
+	},
+}
+
+func DataSourceSite24x7User() *schema.Resource {
+	return &schema.Resource{
+		Read:   userDataSourceRead,
+		Schema: userDataSourceSchema,
+	}
+}
+
+// userDataSourceRead fetches users from Site24x7 based on name_regex
+func userDataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(Client)
+
+	userList, err := client.Users().List()
+	if err != nil {
+		return err
+	}
+
+	nameRegex := d.Get("name_regex").(string)
+	var matchingUserIDs []string
+	var matchingUserIDsAndNames []string
+	var user *api.User
+
+	if nameRegex != "" {
+		nameRegexPattern := regexp.MustCompile("(?i)" + nameRegex)
+		for _, userInfo := range userList {
+			if nameRegexPattern.MatchString(userInfo.DisplayName) {
+				user = userInfo
+				matchingUserIDs = append(matchingUserIDs, userInfo.ID)
+				matchingUserIDsAndNames = append(matchingUserIDsAndNames, userInfo.ID+"__"+userInfo.DisplayName)
+			}
+		}
+	} else {
+		return errors.New("Please enter a value for the attribute name_regex!")
+	}
+
+	if user == nil {
+		return errors.New("Unable to find user matching the name: \"" + nameRegex + "\"")
+	}
+
+	updateUserDataSourceResourceData(d, user, matchingUserIDs, matchingUserIDsAndNames)
+
+	return nil
+}
+
+func updateUserDataSourceResourceData(d *schema.ResourceData, user *api.User, matchingUserIDs []string, matchingUserIDsAndNames []string) {
+	d.SetId(user.ID) // Set the ID to the matched user's ID
+	d.Set("matching_ids", matchingUserIDs)
+	d.Set("matching_ids_and_names", matchingUserIDsAndNames)
+	d.Set("display_name", user.DisplayName)
+	d.Set("email", user.Email)
+	d.Set("user_role", user.UserRole)
+}

--- a/site24x7/user_data_source.go
+++ b/site24x7/user_data_source.go
@@ -21,7 +21,7 @@ var userDataSourceSchema = map[string]*schema.Schema{
 		Description: "List of user IDs matching the name_regex.",
 	},
 	"matching_ids_and_names": {
-		Type:        schema.TypeList,
+		Type:        schema.TypeMap,
 		Computed:    true,
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Description: "List of user IDs and names matching the name_regex.",
@@ -66,7 +66,7 @@ func userDataSourceRead(d *schema.ResourceData, meta interface{}) error {
 
 	nameRegex := d.Get("name_regex").(string)
 	var matchingUserIDs []string
-	var matchingUserIDsAndNames []string
+	matchingUserIDsAndNames := make(map[string]string)
 	var user *api.User
 
 	if nameRegex != "" {
@@ -75,7 +75,7 @@ func userDataSourceRead(d *schema.ResourceData, meta interface{}) error {
 			if nameRegexPattern.MatchString(userInfo.DisplayName) {
 				user = userInfo
 				matchingUserIDs = append(matchingUserIDs, userInfo.ID)
-				matchingUserIDsAndNames = append(matchingUserIDsAndNames, userInfo.ID+"__"+userInfo.DisplayName)
+				matchingUserIDsAndNames[userInfo.ID] = userInfo.DisplayName
 			}
 		}
 	} else {
@@ -91,7 +91,7 @@ func userDataSourceRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func updateUserDataSourceResourceData(d *schema.ResourceData, user *api.User, matchingUserIDs []string, matchingUserIDsAndNames []string) {
+func updateUserDataSourceResourceData(d *schema.ResourceData, user *api.User, matchingUserIDs []string, matchingUserIDsAndNames map[string]string) {
 	d.SetId(user.ID) // Set the ID to the matched user's ID
 	d.Set("matching_ids", matchingUserIDs)
 	d.Set("matching_ids_and_names", matchingUserIDsAndNames)


### PR DESCRIPTION
The following Pull request contains the following changes in our terraform provider, 

1. User data source - Using user data source, customers can fetch the user id and reference it anywhere inside site24x7 Terraform . 
2. Removed default terraform version on main. tf
3. A sample tf file was added for user data source reference. 
4. Documentation updated for user datasource. 