### PR TITLE
Fix CAA DNS monitor cert_auth type issue

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -70,7 +70,7 @@ type SearchConfig struct {
 	Kid      int    `json:"kid,omitempty"`
 	Key      string `json:"key,omitempty"`
 	Tag      string `json:"tag,omitempty"`
-	CertAuth string `json:"cert_auth,omitempty"`
+	CertAuth string `json:"certauth,omitempty"`
 	Halg     int    `json:"halg,omitempty"`
 	Hash     string `json:"hash,omitempty"`
 }


### PR DESCRIPTION
Based on the current API (https://www.site24x7.com/help/api/#dns_search_config), `site24x7_dns_server_monitor`'s `search_config`  has `certauth` instead of `cert_auth` in case of CAA record type. This PR fixes this in the provider.