### PR TITLE
fix: Fix ordering of monitor groups

### DIFF
--- a/site24x7/monitors/cron.go
+++ b/site24x7/monitors/cron.go
@@ -1,6 +1,8 @@
 package monitors
 
 import (
+	"sort",
+	
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/site24x7/terraform-provider-site24x7/api"
 	apierrors "github.com/site24x7/terraform-provider-site24x7/api/errors"
@@ -201,6 +203,7 @@ func resourceDataToCronMonitor(d *schema.ResourceData, client site24x7.Client) (
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
 
 	var userGroupIDs []string
 	for _, id := range d.Get("user_group_ids").(*schema.Set).List() {

--- a/site24x7/monitors/cron.go
+++ b/site24x7/monitors/cron.go
@@ -1,8 +1,8 @@
 package monitors
 
 import (
-	"sort",
-	
+	"sort"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/site24x7/terraform-provider-site24x7/api"
 	apierrors "github.com/site24x7/terraform-provider-site24x7/api/errors"

--- a/site24x7/monitors/dns_server.go
+++ b/site24x7/monitors/dns_server.go
@@ -416,6 +416,7 @@ func resourceDataToDNSServerMonitor(d *schema.ResourceData, client site24x7.Clie
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
 
 	dependencyIDs := d.Get("dependency_resource_ids").(*schema.Set).List()
 	dependencyResourceIDs := make([]string, 0, len(dependencyIDs))

--- a/site24x7/monitors/domain_expiry.go
+++ b/site24x7/monitors/domain_expiry.go
@@ -307,6 +307,8 @@ func resourceDataToDomainExpiryMonitor(d *schema.ResourceData, client site24x7.C
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
+
 	var userGroupIDs []string
 	for _, id := range d.Get("user_group_ids").([]interface{}) {
 		if id != nil {

--- a/site24x7/monitors/ftp_transfer.go
+++ b/site24x7/monitors/ftp_transfer.go
@@ -280,6 +280,8 @@ func resourceDataToFTPTransferMonitor(d *schema.ResourceData, client site24x7.Cl
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
+
 	var userGroupIDs []string
 	for _, id := range d.Get("user_group_ids").([]interface{}) {
 		if id != nil {

--- a/site24x7/monitors/heartbeat.go
+++ b/site24x7/monitors/heartbeat.go
@@ -1,6 +1,8 @@
 package monitors
 
 import (
+	"sort",
+	
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/site24x7/terraform-provider-site24x7/api"
 	apierrors "github.com/site24x7/terraform-provider-site24x7/api/errors"
@@ -191,6 +193,7 @@ func resourceDataToHeartbeatMonitor(d *schema.ResourceData, client site24x7.Clie
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
 
 	var userGroupIDs []string
 	for _, id := range d.Get("user_group_ids").(*schema.Set).List() {

--- a/site24x7/monitors/heartbeat.go
+++ b/site24x7/monitors/heartbeat.go
@@ -1,8 +1,8 @@
 package monitors
 
 import (
-	"sort",
-	
+	"sort"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/site24x7/terraform-provider-site24x7/api"
 	apierrors "github.com/site24x7/terraform-provider-site24x7/api/errors"

--- a/site24x7/monitors/isp.go
+++ b/site24x7/monitors/isp.go
@@ -255,6 +255,8 @@ func resourceDataToISPMonitor(d *schema.ResourceData, client site24x7.Client) (*
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
+
 	var userGroupIDs []string
 	for _, id := range d.Get("user_group_ids").([]interface{}) {
 		if id != nil {

--- a/site24x7/monitors/ping.go
+++ b/site24x7/monitors/ping.go
@@ -241,6 +241,8 @@ func resourceDataToPINGMonitor(d *schema.ResourceData, client site24x7.Client) (
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
+
 	var userGroupIDs []string
 	for _, id := range d.Get("user_group_ids").([]interface{}) {
 		if id != nil {

--- a/site24x7/monitors/port.go
+++ b/site24x7/monitors/port.go
@@ -290,6 +290,8 @@ func resourceDataToPortMonitor(d *schema.ResourceData, client site24x7.Client) (
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
+
 	var userGroupIDs []string
 	for _, id := range d.Get("user_group_ids").([]interface{}) {
 		if id != nil {

--- a/site24x7/monitors/rest_api.go
+++ b/site24x7/monitors/rest_api.go
@@ -521,6 +521,7 @@ func resourceDataToRestApiMonitor(d *schema.ResourceData, client site24x7.Client
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
 
 	dependencyIDs := d.Get("dependency_resource_ids").(*schema.Set).List()
 	dependencyResourceIDs := make([]string, 0, len(dependencyIDs))

--- a/site24x7/monitors/rest_api_transaction.go
+++ b/site24x7/monitors/rest_api_transaction.go
@@ -609,6 +609,7 @@ func resourceDataToRestApiTransactionMonitor(d *schema.ResourceData, client site
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
 
 	dependencyIDs := d.Get("dependency_resource_ids").(*schema.Set).List()
 	dependencyResourceIDs := make([]string, 0, len(dependencyIDs))

--- a/site24x7/monitors/server.go
+++ b/site24x7/monitors/server.go
@@ -1,6 +1,8 @@
 package monitors
 
 import (
+	"sort",
+	
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/site24x7/terraform-provider-site24x7/api"
 	apierrors "github.com/site24x7/terraform-provider-site24x7/api/errors"
@@ -182,6 +184,7 @@ func resourceDataToServerMonitor(d *schema.ResourceData, client site24x7.Client,
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
 
 	var userGroupIDs []string
 	for _, id := range d.Get("user_group_ids").([]interface{}) {

--- a/site24x7/monitors/server.go
+++ b/site24x7/monitors/server.go
@@ -1,8 +1,8 @@
 package monitors
 
 import (
-	"sort",
-	
+	"sort"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/site24x7/terraform-provider-site24x7/api"
 	apierrors "github.com/site24x7/terraform-provider-site24x7/api/errors"

--- a/site24x7/monitors/soap.go
+++ b/site24x7/monitors/soap.go
@@ -326,6 +326,8 @@ func resourceDataToSOAPMonitor(d *schema.ResourceData, client site24x7.Client) (
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
+	
 	var userGroupIDs []string
 	for _, id := range d.Get("user_group_ids").([]interface{}) {
 		if id != nil {

--- a/site24x7/monitors/ssl.go
+++ b/site24x7/monitors/ssl.go
@@ -1,6 +1,8 @@
 package monitors
 
 import (
+	"sort"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/site24x7/terraform-provider-site24x7/api"
 	apierrors "github.com/site24x7/terraform-provider-site24x7/api/errors"
@@ -242,6 +244,7 @@ func resourceDataToSSLMonitor(d *schema.ResourceData, client site24x7.Client) (*
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
 
 	dependencyIDs := d.Get("dependency_resource_ids").(*schema.Set).List()
 	dependencyResourceIDs := make([]string, 0, len(dependencyIDs))

--- a/site24x7/monitors/web_page_speed.go
+++ b/site24x7/monitors/web_page_speed.go
@@ -455,6 +455,7 @@ func resourceDataToWebPageSpeedMonitor(d *schema.ResourceData, client site24x7.C
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
 
 	dependencyIDs := d.Get("dependency_resource_ids").(*schema.Set).List()
 	dependencyResourceIDs := make([]string, 0, len(dependencyIDs))

--- a/site24x7/monitors/web_transaction_browser.go
+++ b/site24x7/monitors/web_transaction_browser.go
@@ -369,6 +369,8 @@ func resourceDataToWebTransactionBrowserMonitorCreate(d *schema.ResourceData, cl
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
+
 	var userGroupIDs []string
 	for _, id := range d.Get("user_group_ids").([]interface{}) {
 		if id != nil {

--- a/site24x7/monitors/website.go
+++ b/site24x7/monitors/website.go
@@ -618,6 +618,7 @@ func resourceDataToWebsiteMonitor(d *schema.ResourceData, client site24x7.Client
 			monitorGroups = append(monitorGroups, group.(string))
 		}
 	}
+	sort.Strings(monitorGroups)
 
 	dependencyIDs := d.Get("dependency_resource_ids").(*schema.Set).List()
 	dependencyResourceIDs := make([]string, 0, len(dependencyIDs))


### PR DESCRIPTION
I've attempted to fix the ordering of monitor groups so that they are deterministic and don't cause mismatches when re-planning. Currently, if you re-plan, some references can denote changes due to the ordering of the groups changing from the order in how they were included.

I'm struggling to test that the change has actually worked though as I can't seem to get the tests running locally