### PR TITLE
Add GCP Project onboarding support with service discovery in Terraform

### DIFF
--- a/api/constants.go
+++ b/api/constants.go
@@ -34,4 +34,5 @@ const (
 	PORT         MonitorType = "PORT"
 	PING         MonitorType = "PING"
 	SOAP         MonitorType = "SOAP"
+	GCP          MonitorType = "GCP"
 )

--- a/api/endpoints/monitors/gcl_impl_test.go
+++ b/api/endpoints/monitors/gcl_impl_test.go
@@ -1,0 +1,179 @@
+package monitors
+
+import (
+	"testing"
+
+	"github.com/site24x7/terraform-provider-site24x7/api"
+	"github.com/site24x7/terraform-provider-site24x7/rest"
+	"github.com/site24x7/terraform-provider-site24x7/validation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGCPMonitors(t *testing.T) {
+	validation.RunTests(t, []*validation.EndpointTest{
+		{
+			Name:         "create gcp monitor",
+			ExpectedVerb: "POST",
+			ExpectedPath: "/monitors",
+			ExpectedBody: validation.Fixture(t, "requests/create_gcp_monitor.json"),
+			StatusCode:   200,
+			ResponseBody: validation.JsonAPIResponseBody(t, nil),
+			Fn: func(t *testing.T, c rest.Client) {
+				gcpMonitor := &api.GCPMonitor{
+					DisplayName:          "GCP Monitor Display Name",
+					Type:                 "GCP",
+					ProjectID:            "project-id",
+					DiscoverServices:     []int{1},
+					CheckFrequency:       "5",
+					StopRediscoverOption: 1,
+					GCPSAContent: struct {
+						PrivateKey  string `json:"private_key"`
+						ClientEmail string `json:"client_email"`
+					}{
+						PrivateKey:  "private-key",
+						ClientEmail: "client-email",
+					},
+					NotificationProfileID: "123412341234123413",
+					UserGroupIDs: []string{
+						"123412341234123415",
+					},
+				}
+
+				_, err := NewGCPMonitors(c).Create(gcpMonitor)
+				require.NoError(t, err)
+			},
+		},
+		{
+			Name:         "get gcp monitor",
+			ExpectedVerb: "GET",
+			ExpectedPath: "/monitors/113770000041271035",
+			StatusCode:   200,
+			ResponseBody: validation.Fixture(t, "responses/get_gcp_monitor.json"),
+			Fn: func(t *testing.T, c rest.Client) {
+				gcpMonitor, err := NewGCPMonitors(c).Get("113770000041271035")
+				require.NoError(t, err)
+
+				expected := &api.GCPMonitor{
+					DisplayName:          "GCP Monitor Display Name",
+					Type:                 "GCP",
+					ProjectID:            "project-id",
+					DiscoverServices:     []int{1},
+					CheckFrequency:       "5",
+					StopRediscoverOption: 1,
+					GCPSAContent: struct {
+						PrivateKey  string `json:"private_key"`
+						ClientEmail string `json:"client_email"`
+					}{
+						PrivateKey:  "private-key",
+						ClientEmail: "client-email",
+					},
+					NotificationProfileID: "123412341234123413",
+					UserGroupIDs: []string{
+						"123412341234123415",
+					},
+				}
+
+				assert.Equal(t, expected, gcpMonitor)
+			},
+		},
+		{
+			Name:         "list gcp monitors",
+			ExpectedVerb: "GET",
+			ExpectedPath: "/monitors",
+			StatusCode:   200,
+			ResponseBody: validation.Fixture(t, "responses/list_gcp_monitors.json"),
+			Fn: func(t *testing.T, c rest.Client) {
+				gcpMonitors, err := NewGCPMonitors(c).List()
+				require.NoError(t, err)
+
+				expected := []*api.GCPMonitor{
+					{
+						MonitorID:            "123447000020646003",
+						DisplayName:          "GCP Monitor Display Name",
+						Type:                 "GCP",
+						ProjectID:            "project-id",
+						DiscoverServices:     []int{1},
+						CheckFrequency:       "5",
+						StopRediscoverOption: 1,
+						GCPSAContent: struct {
+							PrivateKey  string `json:"private_key"`
+							ClientEmail string `json:"client_email"`
+						}{
+							PrivateKey:  "private-key",
+							ClientEmail: "client-email",
+						},
+						NotificationProfileID: "123412341234123413",
+						UserGroupIDs: []string{
+							"123412341234123415",
+						},
+					},
+					{
+						MonitorID:            "123447000020646008",
+						DisplayName:          "GCP Monitor Display Name",
+						Type:                 "GCP",
+						ProjectID:            "project-id",
+						DiscoverServices:     []int{1},
+						CheckFrequency:       "5",
+						StopRediscoverOption: 1,
+						GCPSAContent: struct {
+							PrivateKey  string `json:"private_key"`
+							ClientEmail string `json:"client_email"`
+						}{
+							PrivateKey:  "private-key",
+							ClientEmail: "client-email",
+						},
+						NotificationProfileID: "123412341234123413",
+						UserGroupIDs: []string{
+							"123412341234123415",
+						},
+					},
+				}
+
+				assert.Equal(t, expected, gcpMonitors)
+			},
+		},
+		{
+			Name:         "update gcp monitor",
+			ExpectedVerb: "PUT",
+			ExpectedPath: "/monitors/123",
+			ExpectedBody: validation.Fixture(t, "requests/update_gcp_monitor.json"),
+			StatusCode:   200,
+			ResponseBody: validation.JsonAPIResponseBody(t, nil),
+			Fn: func(t *testing.T, c rest.Client) {
+				gcpMonitor := &api.GCPMonitor{
+					MonitorID:            "123",
+					DisplayName:          "foo",
+					Type:                 "GCP",
+					ProjectID:            "project-id",
+					DiscoverServices:     []int{1},
+					CheckFrequency:       "5",
+					StopRediscoverOption: 1,
+					GCPSAContent: struct {
+						PrivateKey  string `json:"private_key"`
+						ClientEmail string `json:"client_email"`
+					}{
+						PrivateKey:  "private-key",
+						ClientEmail: "client-email",
+					},
+					NotificationProfileID: "123412341234123413",
+					UserGroupIDs: []string{
+						"123412341234123415",
+					},
+				}
+
+				_, err := NewGCPMonitors(c).Update(gcpMonitor)
+				require.NoError(t, err)
+			},
+		},
+		{
+			Name:         "delete gcp monitor",
+			ExpectedVerb: "DELETE",
+			ExpectedPath: "/monitors/123",
+			StatusCode:   200,
+			Fn: func(t *testing.T, c rest.Client) {
+				require.NoError(t, NewGCPMonitors(c).Delete("123"))
+			},
+		},
+	})
+}

--- a/api/endpoints/monitors/gcp_impl.go
+++ b/api/endpoints/monitors/gcp_impl.go
@@ -1,0 +1,103 @@
+package monitors
+
+import (
+	"github.com/site24x7/terraform-provider-site24x7/api"
+	"github.com/site24x7/terraform-provider-site24x7/rest"
+)
+
+type GCPMonitors interface {
+	Get(monitorID string) (*api.GCPMonitor, error)
+	Create(monitor *api.GCPMonitor) (*api.GCPMonitor, error)
+	Update(monitor *api.GCPMonitor) (*api.GCPMonitor, error)
+	Delete(monitorID string) error
+	List() ([]*api.GCPMonitor, error)
+	Activate(monitorID string) error
+	Suspend(monitorID string) error
+}
+
+type gcpMonitors struct {
+	client rest.Client
+}
+
+func NewGCPMonitors(client rest.Client) GCPMonitors {
+	return &gcpMonitors{
+		client: client,
+	}
+}
+
+func (c *gcpMonitors) Get(monitorID string) (*api.GCPMonitor, error) {
+	monitor := &api.GCPMonitor{}
+	err := c.client.
+		Get().
+		Resource("monitors").
+		ResourceID(monitorID).
+		Do().
+		Parse(monitor)
+
+	return monitor, err
+}
+
+func (c *gcpMonitors) Create(monitor *api.GCPMonitor) (*api.GCPMonitor, error) {
+	newMonitor := &api.GCPMonitor{}
+	err := c.client.
+		Post().
+		Resource("monitors").
+		AddHeader("Content-Type", "application/json;charset=UTF-8").
+		Body(monitor).
+		Do().
+		Parse(newMonitor)
+
+	return newMonitor, err
+}
+
+func (c *gcpMonitors) Update(monitor *api.GCPMonitor) (*api.GCPMonitor, error) {
+	updatedMonitor := &api.GCPMonitor{}
+	err := c.client.
+		Put().
+		Resource("monitors").
+		ResourceID(monitor.MonitorID).
+		AddHeader("Content-Type", "application/json;charset=UTF-8").
+		Body(monitor).
+		Do().
+		Parse(updatedMonitor)
+
+	return updatedMonitor, err
+}
+
+func (c *gcpMonitors) Delete(monitorID string) error {
+	return c.client.
+		Delete().
+		Resource("monitors").
+		ResourceID(monitorID).
+		Do().
+		Err()
+}
+
+func (c *gcpMonitors) List() ([]*api.GCPMonitor, error) {
+	monitors := []*api.GCPMonitor{}
+	err := c.client.
+		Get().
+		Resource("monitors").
+		Do().
+		Parse(&monitors)
+
+	return monitors, err
+}
+
+func (c *gcpMonitors) Activate(monitorID string) error {
+	return c.client.
+		Put().
+		Resource("monitors/activate").
+		ResourceID(monitorID).
+		Do().
+		Err()
+}
+
+func (c *gcpMonitors) Suspend(monitorID string) error {
+	return c.client.
+		Put().
+		Resource("monitors/suspend").
+		ResourceID(monitorID).
+		Do().
+		Err()
+}

--- a/api/monitor_types.go
+++ b/api/monitor_types.go
@@ -1165,3 +1165,74 @@ func (DNSServerMonitor *DNSServerMonitor) GetTagIDs() []string {
 func (DNSServerMonitor *DNSServerMonitor) String() string {
 	return ToString(DNSServerMonitor)
 }
+
+type GCPMonitor struct {
+	_                    struct{} `type:"structure"` // Enforces key-based initialization.
+	MonitorID            string   `json:"monitor_id,omitempty"`
+	DisplayName          string   `json:"display_name"`
+	Type                 string   `json:"type"`
+	ProjectID            string   `json:"project_id"`
+	DiscoverServices     []int    `json:"gcp_discover_services,omitempty"`
+	CheckFrequency       string   `json:"check_frequency"`
+	StopRediscoverOption int      `json:"stop_rediscover_option"`
+	GCPSAContent         struct {
+		PrivateKey  string `json:"private_key"`
+		ClientEmail string `json:"client_email"`
+	} `json:"gcp_sa_content"`
+	UserGroupIDs          []string `json:"user_group_ids"`
+	TagIDs                []string `json:"tag_ids,omitempty"`
+	NotificationProfileID string   `json:"notification_profile_id"`
+	GCPTagsType           int      `json:"gcp_tags_type,omitempty"`
+	GCPTags               []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	} `json:"gcp_tags,omitempty"`
+}
+
+func (gcpMonitor *GCPMonitor) SetTagIDs(tagIDs []string) {
+	gcpMonitor.TagIDs = tagIDs
+}
+
+func (gcpMonitor *GCPMonitor) GetTagIDs() []string {
+	return gcpMonitor.TagIDs
+}
+
+func (gcpMonitor *GCPMonitor) SetLocationProfileID(locationProfileID string) {
+}
+
+func (gcpMonitor *GCPMonitor) GetLocationProfileID() string {
+	return ""
+}
+func (gcpMonitor *GCPMonitor) SetNotificationProfileID(notificationProfileID string) {
+	gcpMonitor.NotificationProfileID = notificationProfileID
+}
+
+func (gcpMonitor *GCPMonitor) GetNotificationProfileID() string {
+	return gcpMonitor.NotificationProfileID
+}
+
+func (gcpMonitor *GCPMonitor) SetUserGroupIDs(userGroupIDs []string) {
+	gcpMonitor.UserGroupIDs = userGroupIDs
+}
+
+func (gcpMonitor *GCPMonitor) GetUserGroupIDs() []string {
+	return gcpMonitor.UserGroupIDs
+}
+
+func (gcpMonitor *GCPMonitor) SetGCPTags(gcpTags []struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}) {
+	gcpMonitor.GCPTags = gcpTags
+}
+
+func (gcpMonitor *GCPMonitor) GetGCPTags() []struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+} {
+	return gcpMonitor.GCPTags
+}
+
+func (gcpMonitor *GCPMonitor) String() string {
+	return ToString(gcpMonitor)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -79,6 +79,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"site24x7_amazon_monitor":                  monitors.ResourceSite24x7AmazonMonitor(),
+			"site24x7_gcp_monitor":                     monitors.ResourceSite24x7GCPMonitor(),
 			"site24x7_website_monitor":                 monitors.ResourceSite24x7WebsiteMonitor(),
 			"site24x7_web_page_speed_monitor":          monitors.ResourceSite24x7WebPageSpeedMonitor(),
 			"site24x7_ssl_monitor":                     monitors.ResourceSite24x7SSLMonitor(),

--- a/site24x7/client.go
+++ b/site24x7/client.go
@@ -101,6 +101,7 @@ type Client interface {
 	RestApiMonitors() monitors.RestApiMonitors
 	RestApiTransactionMonitors() monitors.RestApiTransactionMonitors
 	AmazonMonitors() monitors.AmazonMonitors
+	GCPMonitors() monitors.GCPMonitors
 	NotificationProfiles() endpoints.NotificationProfiles
 	ThresholdProfiles() endpoints.ThresholdProfiles
 	Users() endpoints.Users
@@ -186,6 +187,11 @@ func (c *client) LocationTemplate() endpoints.LocationTemplate {
 // AmazonMonitors implements Client.
 func (c *client) AmazonMonitors() monitors.AmazonMonitors {
 	return monitors.NewAmazonMonitors(c.restClient)
+}
+
+// GCPMonitors implements Client.
+func (c *client) GCPMonitors() monitors.GCPMonitors {
+	return monitors.NewGCPMonitors(c.restClient)
 }
 
 // WebsiteMonitors implements Client.

--- a/site24x7/monitors/gcp.go
+++ b/site24x7/monitors/gcp.go
@@ -1,0 +1,326 @@
+package monitors
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/site24x7/terraform-provider-site24x7/api"
+	apierrors "github.com/site24x7/terraform-provider-site24x7/api/errors"
+	"github.com/site24x7/terraform-provider-site24x7/site24x7"
+)
+
+var GCPMonitorSchema = map[string]*schema.Schema{
+	"display_name": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Display name for the GCP monitor.",
+	},
+	"project_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Project ID of the GCP account.",
+	},
+	"private_key": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Sensitive:   true,
+		Description: "Private key for GCP Service Account authentication.",
+	},
+	"client_email": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Client email for GCP Service Account authentication.",
+	},
+	"gcp_discovery_frequency": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Default:     "1",
+		Description: "Rediscovery polling interval for the GCP account.",
+	},
+	"stop_rediscover_option": {
+		Type:        schema.TypeInt,
+		Required:    true,
+		Description: "Preferred rediscovery frequency.",
+	},
+	"gcp_discover_services": {
+		Type: schema.TypeList,
+		Elem: &schema.Schema{
+			Type: schema.TypeInt,
+		},
+		Optional:    true,
+		Description: "List of GCP services that need to be discovered.",
+	},
+	"notification_profile_id": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Computed:    true,
+		Description: "Notification profile to be associated with the monitor.",
+	},
+	"notification_profile_name": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Name of the notification profile to be associated with the monitor.",
+	},
+	"user_group_ids": {
+		Type: schema.TypeList,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+		Optional:    true,
+		Computed:    true,
+		Description: "List of user groups to be notified when the monitor is down.",
+	},
+	"user_group_names": {
+		Type: schema.TypeList,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+		Optional:    true,
+		Description: "Name of the user groups to be associated with the monitor.",
+	},
+	"tag_ids": {
+		Type: schema.TypeSet,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+		Optional:    true,
+		Computed:    true,
+		Description: "List of tag IDs to be associated with the monitor.",
+	},
+	"tag_names": {
+		Type: schema.TypeList,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+		Optional:    true,
+		Description: "List of tag names to be associated with the monitor.",
+	},
+	"third_party_service_ids": {
+		Type: schema.TypeList,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+		Optional:    true,
+		Description: "List of Third Party Service IDs to be associated with the monitor.",
+	},
+}
+
+func ResourceSite24x7GCPMonitor() *schema.Resource {
+	return &schema.Resource{
+		Create: gcpMonitorCreate,
+		Read:   gcpMonitorRead,
+		Update: gcpMonitorUpdate,
+		Delete: gcpMonitorDelete,
+		Exists: gcpMonitorExists,
+
+		Schema: GCPMonitorSchema,
+	}
+}
+
+func gcpMonitorCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(site24x7.Client)
+
+	monitor, err := resourceDataToGCPMonitor(d, client)
+	if err != nil {
+		return err
+	}
+
+	// Convert struct to JSON and print
+	monitorJSON, err := json.MarshalIndent(monitor, "", "  ")
+	if err != nil {
+		return err
+	}
+	log.Println("========== START OF GCP MONITOR JSON ==========")
+	log.Println(string(monitorJSON)) // Prints the JSON representation
+	log.Println("========== END OF GCP MONITOR JSON ==========")
+
+	gcpMonitor, err := client.GCPMonitors().Create(monitor)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(gcpMonitor.MonitorID)
+
+	return nil
+}
+
+func gcpMonitorRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(site24x7.Client)
+
+	gcpMonitor, err := client.GCPMonitors().Get(d.Id())
+	if err != nil {
+		return err
+	}
+
+	updateGCPMonitorResourceData(d, gcpMonitor)
+
+	return nil
+}
+
+func gcpMonitorUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(site24x7.Client)
+
+	gcpMonitor, err := resourceDataToGCPMonitor(d, client)
+	if err != nil {
+		return err
+	}
+	if d.HasChange("gcp_discover_services") {
+		var gcpServicesToDiscover []int
+		if v, ok := d.GetOk("gcp_discover_services"); ok {
+			for _, id := range v.([]interface{}) {
+				if num, ok := id.(int); ok {
+					gcpServicesToDiscover = append(gcpServicesToDiscover, num)
+				}
+			}
+		}
+		gcpMonitor.DiscoverServices = gcpServicesToDiscover
+	}
+	gcpMonitor, err = client.GCPMonitors().Update(gcpMonitor)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(gcpMonitor.MonitorID)
+
+	return nil
+}
+
+func gcpMonitorDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(site24x7.Client)
+
+	err := client.GCPMonitors().Delete(d.Id())
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	return err
+}
+
+func gcpMonitorExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(site24x7.Client)
+
+	_, err := client.GCPMonitors().Get(d.Id())
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func resourceDataToGCPMonitor(d *schema.ResourceData, client site24x7.Client) (*api.GCPMonitor, error) {
+	var userGroupIDs []string
+	for _, id := range d.Get("user_group_ids").([]interface{}) {
+		if id != nil {
+			userGroupIDs = append(userGroupIDs, id.(string))
+		}
+	}
+
+	var gcpServicesToDiscover []int
+	for _, id := range d.Get("gcp_discover_services").([]interface{}) {
+		if num, ok := id.(int); ok {
+			gcpServicesToDiscover = append(gcpServicesToDiscover, num)
+		}
+	}
+
+	if len(userGroupIDs) == 0 {
+		userGroup, err := site24x7.DefaultUserGroup(client)
+		if err != nil {
+			return nil, err
+		}
+		userGroupIDs = append(userGroupIDs, userGroup.UserGroupID)
+	}
+	var gcpTags []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}
+
+	var tagIDs []string
+	for _, id := range d.Get("tag_ids").(*schema.Set).List() {
+		if id != nil {
+			tagIDs = append(tagIDs, id.(string))
+		}
+	}
+
+	if v, ok := d.Get("gcp_tags").([]interface{}); ok {
+		for _, tag := range v {
+			if tagMap, ok := tag.(map[string]interface{}); ok {
+				gcpTags = append(gcpTags, struct {
+					Name  string `json:"name"`
+					Value string `json:"value"`
+				}{
+					Name:  tagMap["name"].(string),
+					Value: tagMap["value"].(string),
+				})
+			}
+		}
+	}
+
+	gcpMonitor := &api.GCPMonitor{
+		MonitorID:             d.Id(),
+		DisplayName:           d.Get("display_name").(string),
+		Type:                  string(api.GCP),
+		CheckFrequency:        d.Get("gcp_discovery_frequency").(string),
+		StopRediscoverOption:  d.Get("stop_rediscover_option").(int),
+		DiscoverServices:      gcpServicesToDiscover,
+		ProjectID:             d.Get("project_id").(string),
+		NotificationProfileID: d.Get("notification_profile_id").(string),
+		UserGroupIDs:          userGroupIDs,
+		TagIDs:                tagIDs,
+		GCPTags:               gcpTags,
+		GCPSAContent: struct {
+			PrivateKey  string `json:"private_key"`
+			ClientEmail string `json:"client_email"`
+		}{
+			PrivateKey:  d.Get("private_key").(string),
+			ClientEmail: d.Get("client_email").(string),
+		},
+	}
+
+	// Notification Profile
+	_, notificationProfileErr := site24x7.SetNotificationProfile(client, d, gcpMonitor)
+	if notificationProfileErr != nil {
+		return nil, notificationProfileErr
+	}
+	// Tags
+	_, tagsErr := site24x7.SetTags(client, d, gcpMonitor)
+	if tagsErr != nil {
+		return nil, tagsErr
+	}
+	// User Alert Groups
+	_, userAlertGroupErr := site24x7.SetUserGroup(client, d, gcpMonitor)
+	if userAlertGroupErr != nil {
+		return nil, userAlertGroupErr
+	}
+
+	return gcpMonitor, nil
+}
+
+func updateGCPMonitorResourceData(d *schema.ResourceData, gcpmonitor *api.GCPMonitor) {
+	d.Set("display_name", gcpmonitor.DisplayName)
+	d.Set("project_id", gcpmonitor.ProjectID)
+	if v, ok := d.GetOk("private_key"); ok && v.(string) != "" {
+		d.Set("private_key", v)
+	}
+	if v, ok := d.GetOk("client_email"); ok && v.(string) != "" {
+		d.Set("client_email", v)
+	}
+	d.Set("gcp_discovery_frequency", gcpmonitor.CheckFrequency)
+	d.Set("stop_rediscover_option", gcpmonitor.StopRediscoverOption)
+	d.Set("gcp_discover_services", gcpmonitor.DiscoverServices)
+	d.Set("notification_profile_id", gcpmonitor.NotificationProfileID)
+	d.Set("user_group_ids", gcpmonitor.UserGroupIDs)
+	d.Set("tag_ids", gcpmonitor.TagIDs)
+	var gcpTags []map[string]string
+	for _, tag := range gcpmonitor.GCPTags {
+		gcpTags = append(gcpTags, map[string]string{
+			"name":  tag.Name,
+			"value": tag.Value,
+		})
+	}
+	d.Set("gcp_tags", gcpTags)
+}


### PR DESCRIPTION
* Implemented GCP monitor creation with Terraform support.
* Added validation tests for GCP onboarding.
* Updated DiscoverServices to support service discovery.
* Ensured sensitive credentials remain unchanged.