### PR TITLE
The Site24x7 Terraform provider's user agent has been updated to incl…

### DIFF
--- a/api/monitor_types.go
+++ b/api/monitor_types.go
@@ -1167,15 +1167,16 @@ func (DNSServerMonitor *DNSServerMonitor) String() string {
 }
 
 type GCPMonitor struct {
-	_                    struct{} `type:"structure"` // Enforces key-based initialization.
-	MonitorID            string   `json:"monitor_id,omitempty"`
-	DisplayName          string   `json:"display_name"`
-	Type                 string   `json:"type"`
-	ProjectID            string   `json:"project_id"`
-	DiscoverServices     []int    `json:"gcp_discover_services,omitempty"`
-	CheckFrequency       string   `json:"check_frequency"`
-	StopRediscoverOption int      `json:"stop_rediscover_option"`
-	GCPSAContent         struct {
+	_                     struct{} `type:"structure"` // Enforces key-based initialization.
+	MonitorID             string   `json:"monitor_id,omitempty"`
+	DisplayName           string   `json:"display_name"`
+	Type                  string   `json:"type"`
+	ProjectID             string   `json:"project_id"`
+	DiscoverServices      []int    `json:"gcp_discover_services,omitempty"`
+	CheckFrequency        string   `json:"check_frequency"`
+	GcpRegistrationMethod string   `json:"gcp_registration_method,omitempty"`
+	StopRediscoverOption  int      `json:"stop_rediscover_option"`
+	GCPSAContent          struct {
 		PrivateKey  string `json:"private_key"`
 		ClientEmail string `json:"client_email"`
 	} `json:"gcp_sa_content"`

--- a/rest/request.go
+++ b/rest/request.go
@@ -42,7 +42,7 @@ func NewRequest(client HTTPClient, config ClientConfig) *Request {
 		r.cookie = &http.Cookie{Name: "zaaid", Value: config.ZAAID}
 	}
 	r.AddHeader("Accept", "application/json; version=2.1")
-	r.AddHeader("User-Agent", "Site24x7TerraformProvider/1.0.0")
+	r.AddHeader("User-Agent", "S24x7TerraformProvider/1.0.0")
 	return r
 }
 


### PR DESCRIPTION
The Site24x7 Terraform provider's user agent has been updated to include metadata for tracking API consumption under Developer Settings. Earlier it was consider as a Internal API calls. 