### PR TITLE
Add a state setting to suspend/activate monitors

### DIFF
--- a/api/monitor_types.go
+++ b/api/monitor_types.go
@@ -69,6 +69,7 @@ type WebsiteMonitor struct {
 	SecondaryProtocolSeverity int      `json:"secondary_protocol_severity,omitempty"`
 	HiddenMonAdded            int      `json:"hidden_mon_added,omitempty"`
 	UseIPV6                   bool     `json:"use_ipv6,omitempty"`
+	State                     int      `json:"state"`
 	// HTTP Configuration
 	HTTPMethod                string   `json:"http_method"`
 	RequestContentType        string   `json:"request_content_type,omitempty"`

--- a/site24x7/monitors/website.go
+++ b/site24x7/monitors/website.go
@@ -373,6 +373,12 @@ var websiteMonitorSchema = map[string]*schema.Schema{
 		Elem:        schema.TypeString,
 		Description: "Action to be performed on monitor IT Automation templates.",
 	},
+	"state": {
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Default:     0,
+		Description: "Set the state of the monitor, 0 for enabled, 5 for suspended.",
+	},
 }
 
 func ResourceSite24x7WebsiteMonitor() *schema.Resource {
@@ -564,6 +570,7 @@ func resourceDataToWebsiteMonitor(d *schema.ResourceData, client site24x7.Client
 	websiteMonitor.FollowHTTPRedirection = d.Get("follow_http_redirection").(bool)
 	websiteMonitor.IgnoreCertError = d.Get("ignore_cert_err").(bool)
 	websiteMonitor.IPType = d.Get("ip_type").(int)
+	websiteMonitor.State = d.Get("state").(int)
 
 	if websiteMonitor.IPType == 0 {
 		websiteMonitor.UseIPV6 = false
@@ -731,6 +738,7 @@ func updateWebsiteMonitorResourceData(d *schema.ResourceData, monitor *api.Websi
 	d.Set("use_alpn", monitor.UseAlpn)
 	d.Set("follow_http_redirection", monitor.FollowHTTPRedirection)
 	d.Set("ignore_cert_err", monitor.IgnoreCertError)
+	d.Set("state", monitor.State)
 	// ================================ Content Checks ================================
 	if monitor.MatchingKeyword != nil {
 		d.Set("matching_keyword_value", monitor.MatchingKeyword.Value)

--- a/site24x7/monitors/website.go
+++ b/site24x7/monitors/website.go
@@ -409,7 +409,17 @@ func websiteMonitorCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(websiteMonitor.MonitorID)
 
-	// return websiteMonitorRead(d, meta)
+	desiredState := d.Get("state").(int)
+	if desiredState == 5 {
+		if err := client.WebsiteMonitors().Suspend(websiteMonitor.MonitorID); err != nil {
+			return err
+		}
+	} else if desiredState == 0 {
+		if err := client.WebsiteMonitors().Activate(websiteMonitor.MonitorID); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -438,7 +448,17 @@ func websiteMonitorUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(websiteMonitor.MonitorID)
 
-	// return websiteMonitorRead(d, meta)
+	desiredState := d.Get("state").(int)
+	if desiredState == 5 {
+		if err := client.WebsiteMonitors().Suspend(websiteMonitor.MonitorID); err != nil {
+			return err
+		}
+	} else if desiredState == 0 {
+		if err := client.WebsiteMonitors().Activate(websiteMonitor.MonitorID); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Add ability to suspend and activate monitors with terraform. I'm not sure of the exact schema of the `state` property, but from the API I've been able to see it's 0 when activated and 5 when suspended.

I've tested this and it seems to work pretty well.