### PR TITLE
"interface {} is nil, not string" exception with incorrect parameters (without value) #337

### DIFF
--- a/site24x7/monitors/domain_expiry.go
+++ b/site24x7/monitors/domain_expiry.go
@@ -436,6 +436,7 @@ func updateDomainExpiryMonitorResourceData(d *schema.ResourceData, monitor *api.
 		}else{
 			unmatchingKeywordMap["value"] = monitor.UnmatchingKeyword["value"]
 		}
+		
 		d.Set("unmatching_keyword", unmatchingKeywordMap)
 	}
 	


### PR DESCRIPTION
https://github.com/site24x7/terraform-provider-site24x7/issues/337