### PR TITLE
Site 24x7 Azure monitor addition support handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A terraform provider for managing the following resources in Site24x7:
 
 - Amazon Monitor - [site24x7_amazon_monitor](examples/amazon_monitor_us.tf) ([Site24x7 Amazon Monitor Terraform doc](https://registry.terraform.io/providers/site24x7/site24x7/latest/docs/resources/amazon_monitor))
 - GCP Monitor - [site24x7_GCP_monitor](examples/gcp_monitor_us.tf) ([Site24x7 GCP Monitor Terraform doc](https://registry.terraform.io/providers/site24x7/site24x7/latest/docs/resources/gcp_monitor))
+- Azure Monitor - [site24x7_AZURE_monitor](examples/azure_monitor_us.tf) ([Site24x7 AZURE Monitor Terraform doc](https://registry.terraform.io/providers/site24x7/site24x7/latest/docs/resources/azure_monitor))
 - Website Monitor - [site24x7_website_monitor](examples/website_monitor_us.tf) ([Site24x7 Website Monitor API doc](https://www.site24x7.com/help/api/#website))
 - DNS Server Monitor - [site24x7_dns_server_monitor](examples/dns_server_monitor_us.tf) ([Site24x7 DNS Server Monitor API doc](https://www.site24x7.com/help/api/#dns-server))
 - Web Page Speed (Browser) Monitor - [site24x7_web_page_speed_monitor](examples/web_page_speed_monitor_us.tf) ([Site24x7 Web Page Speed Monitor API doc](https://www.site24x7.com/help/api/#web-page-speed-(browser)))

--- a/api/constants.go
+++ b/api/constants.go
@@ -35,4 +35,5 @@ const (
 	PING         MonitorType = "PING"
 	SOAP         MonitorType = "SOAP"
 	GCP          MonitorType = "GCP"
+	AZURE        MonitorType = "AZURE"
 )

--- a/api/endpoints/fake/azure_monitors.go
+++ b/api/endpoints/fake/azure_monitors.go
@@ -1,0 +1,60 @@
+package fake
+
+import (
+	"github.com/site24x7/terraform-provider-site24x7/api"
+	"github.com/site24x7/terraform-provider-site24x7/api/endpoints/monitors"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ monitors.AzureMonitors = &AzureMonitors{}
+
+type AzureMonitors struct {
+	mock.Mock
+}
+
+func (e *AzureMonitors) Get(monitorID string) (*api.AzureMonitor, error) {
+	args := e.Called(monitorID)
+	if obj, ok := args.Get(0).(*api.AzureMonitor); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *AzureMonitors) Create(monitor *api.AzureMonitor) (*api.AzureMonitor, error) {
+	args := e.Called(monitor)
+	if obj, ok := args.Get(0).(*api.AzureMonitor); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *AzureMonitors) Update(monitor *api.AzureMonitor) (*api.AzureMonitor, error) {
+	args := e.Called(monitor)
+	if obj, ok := args.Get(0).(*api.AzureMonitor); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *AzureMonitors) Delete(monitorID string) error {
+	args := e.Called(monitorID)
+	return args.Error(0)
+}
+
+func (e *AzureMonitors) List() ([]*api.AzureMonitor, error) {
+	args := e.Called()
+	if obj, ok := args.Get(0).([]*api.AzureMonitor); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *AzureMonitors) Activate(monitorID string) error {
+	args := e.Called(monitorID)
+	return args.Error(0)
+}
+
+func (e *AzureMonitors) Suspend(monitorID string) error {
+	args := e.Called(monitorID)
+	return args.Error(0)
+}

--- a/api/endpoints/monitors/azure_impl.go
+++ b/api/endpoints/monitors/azure_impl.go
@@ -1,0 +1,103 @@
+package monitors
+
+import (
+	"github.com/site24x7/terraform-provider-site24x7/api"
+	"github.com/site24x7/terraform-provider-site24x7/rest"
+)
+
+type AzureMonitors interface {
+	Get(monitorID string) (*api.AzureMonitor, error)
+	Create(monitor *api.AzureMonitor) (*api.AzureMonitor, error)
+	Update(monitor *api.AzureMonitor) (*api.AzureMonitor, error)
+	Delete(monitorID string) error
+	List() ([]*api.AzureMonitor, error)
+	Activate(monitorID string) error
+	Suspend(monitorID string) error
+}
+
+type azureMonitors struct {
+	client rest.Client
+}
+
+func NewAzureMonitors(client rest.Client) AzureMonitors {
+	return &azureMonitors{
+		client: client,
+	}
+}
+
+func (c *azureMonitors) Get(monitorID string) (*api.AzureMonitor, error) {
+	monitor := &api.AzureMonitor{}
+	err := c.client.
+		Get().
+		Resource("monitors").
+		ResourceID(monitorID).
+		Do().
+		Parse(monitor)
+
+	return monitor, err
+}
+
+func (c *azureMonitors) Create(monitor *api.AzureMonitor) (*api.AzureMonitor, error) {
+	newMonitor := &api.AzureMonitor{}
+	err := c.client.
+		Post().
+		Resource("monitors").
+		AddHeader("Content-Type", "application/json;charset=UTF-8").
+		Body(monitor).
+		Do().
+		Parse(newMonitor)
+
+	return newMonitor, err
+}
+
+func (c *azureMonitors) Update(monitor *api.AzureMonitor) (*api.AzureMonitor, error) {
+	updatedMonitor := &api.AzureMonitor{}
+	err := c.client.
+		Put().
+		Resource("monitors").
+		ResourceID(monitor.MonitorID).
+		AddHeader("Content-Type", "application/json;charset=UTF-8").
+		Body(monitor).
+		Do().
+		Parse(updatedMonitor)
+
+	return updatedMonitor, err
+}
+
+func (c *azureMonitors) Delete(monitorID string) error {
+	return c.client.
+		Delete().
+		Resource("monitors").
+		ResourceID(monitorID).
+		Do().
+		Err()
+}
+
+func (c *azureMonitors) List() ([]*api.AzureMonitor, error) {
+	monitors := []*api.AzureMonitor{}
+	err := c.client.
+		Get().
+		Resource("monitors").
+		Do().
+		Parse(&monitors)
+
+	return monitors, err
+}
+
+func (c *azureMonitors) Activate(monitorID string) error {
+	return c.client.
+		Put().
+		Resource("monitors/activate").
+		ResourceID(monitorID).
+		Do().
+		Err()
+}
+
+func (c *azureMonitors) Suspend(monitorID string) error {
+	return c.client.
+		Put().
+		Resource("monitors/suspend").
+		ResourceID(monitorID).
+		Do().
+		Err()
+}

--- a/api/endpoints/monitors/azure_impl_test.go
+++ b/api/endpoints/monitors/azure_impl_test.go
@@ -1,0 +1,120 @@
+package monitors
+
+import (
+	"testing"
+
+	"github.com/site24x7/terraform-provider-site24x7/api"
+	"github.com/site24x7/terraform-provider-site24x7/rest"
+	"github.com/site24x7/terraform-provider-site24x7/validation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAzureMonitors(t *testing.T) {
+	validation.RunTests(t, []*validation.EndpointTest{
+		{
+			Name:         "create azure monitor",
+			ExpectedVerb: "POST",
+			ExpectedPath: "/monitors",
+			ExpectedBody: validation.Fixture(t, "requests/create_azure_monitor.json"),
+			StatusCode:   200,
+			ResponseBody: validation.JsonAPIResponseBody(t, nil),
+			Fn: func(t *testing.T, c rest.Client) {
+				azureMonitor := &api.AzureMonitor{
+					DisplayName:           "Azure Monitor Display Name",
+					TenantID:              "tenant-id",
+					ClientID:              "client-id",
+					ClientSecret:          "client-secret",
+					Type:                  "AZURE",
+					Services:              []string{"VirtualMachines"},
+					ManagementGroupReg:    0,
+					NotificationProfileID: "np-id",
+					UserGroupIDs:          []string{"ug-id"},
+					ThresholdProfileID:    "tp-id",
+					DiscoveryInterval:     "60",
+					AutoAddSubscription:   1,
+				}
+
+				_, err := NewAzureMonitors(c).Create(azureMonitor)
+				require.NoError(t, err)
+			},
+		},
+		{
+			Name:         "get azure monitor",
+			ExpectedVerb: "GET",
+			ExpectedPath: "/monitors/azure-monitor-id",
+			StatusCode:   200,
+			ResponseBody: validation.Fixture(t, "responses/get_azure_monitor.json"),
+			Fn: func(t *testing.T, c rest.Client) {
+				azureMonitor, err := NewAzureMonitors(c).Get("azure-monitor-id")
+				require.NoError(t, err)
+
+				expected := &api.AzureMonitor{
+					DisplayName:           "Azure Monitor Display Name",
+					TenantID:              "tenant-id",
+					ClientID:              "client-id",
+					ClientSecret:          "client-secret",
+					Type:                  "AZURE",
+					Services:              []string{"VirtualMachines"},
+					ManagementGroupReg:    0,
+					NotificationProfileID: "np-id",
+					UserGroupIDs:          []string{"ug-id"},
+					ThresholdProfileID:    "tp-id",
+					DiscoveryInterval:     "60",
+					AutoAddSubscription:   1,
+				}
+
+				assert.Equal(t, expected, azureMonitor)
+			},
+		},
+		{
+			Name:         "list azure monitors",
+			ExpectedVerb: "GET",
+			ExpectedPath: "/monitors",
+			StatusCode:   200,
+			ResponseBody: validation.Fixture(t, "responses/list_azure_monitors.json"),
+			Fn: func(t *testing.T, c rest.Client) {
+				monitors, err := NewAzureMonitors(c).List()
+				require.NoError(t, err)
+				assert.Len(t, monitors, 2)
+			},
+		},
+		{
+			Name:         "update azure monitor",
+			ExpectedVerb: "PUT",
+			ExpectedPath: "/monitors/azure-monitor-id",
+			ExpectedBody: validation.Fixture(t, "requests/update_azure_monitor.json"),
+			StatusCode:   200,
+			ResponseBody: validation.JsonAPIResponseBody(t, nil),
+			Fn: func(t *testing.T, c rest.Client) {
+				azureMonitor := &api.AzureMonitor{
+					MonitorID:             "azure-monitor-id",
+					DisplayName:           "Updated Azure Monitor",
+					TenantID:              "tenant-id",
+					ClientID:              "client-id",
+					ClientSecret:          "client-secret",
+					Type:                  "AZURE",
+					Services:              []string{"VirtualMachines"},
+					ManagementGroupReg:    1,
+					NotificationProfileID: "np-id",
+					UserGroupIDs:          []string{"ug-id"},
+					ThresholdProfileID:    "tp-id",
+					DiscoveryInterval:     "360",
+					AutoAddSubscription:   0,
+				}
+
+				_, err := NewAzureMonitors(c).Update(azureMonitor)
+				require.NoError(t, err)
+			},
+		},
+		{
+			Name:         "delete azure monitor",
+			ExpectedVerb: "DELETE",
+			ExpectedPath: "/monitors/azure-monitor-id",
+			StatusCode:   200,
+			Fn: func(t *testing.T, c rest.Client) {
+				require.NoError(t, NewAzureMonitors(c).Delete("azure-monitor-id"))
+			},
+		},
+	})
+}

--- a/api/monitor_types.go
+++ b/api/monitor_types.go
@@ -1237,3 +1237,58 @@ func (gcpMonitor *GCPMonitor) GetGCPTags() []struct {
 func (gcpMonitor *GCPMonitor) String() string {
 	return ToString(gcpMonitor)
 }
+
+type AzureMonitor struct {
+	_                     struct{}           `type:"structure"` // Enforces key-based initialization.
+	MonitorID             string             `json:"monitor_id,omitempty"`
+	DisplayName           string             `json:"display_name"`
+	TenantID              string             `json:"tenant_id"`
+	ClientID              string             `json:"client_id"`
+	ClientSecret          string             `json:"client_secret"`
+	Type                  string             `json:"type"` // Always set to "AZURE"
+	Services              []string           `json:"services"`
+	ManagementGroupReg    int                `json:"management_group_reg"`
+	NotificationProfileID string             `json:"notification_profile_id"`
+	UserGroupIDs          []string           `json:"user_group_ids"`
+	ThresholdProfileID    string             `json:"threshold_profile_id"`
+	DiscoveryInterval     string             `json:"discovery_interval,omitempty"`
+	AutoAddSubscription   int                `json:"auto_add_subscription,omitempty"`
+	AzureExcludeTags      *AzureTagCondition `json:"azure_exclude_tags,omitempty"`
+	AzureIncludeTags      *AzureTagCondition `json:"azure_include_tags,omitempty"`
+	ThirdPartyServiceIDs  []string           `json:"third_party_services,omitempty"`
+}
+
+// JSON structure for include/exclude tags
+type AzureTagCondition struct {
+	Type int                 `json:"type"` // 1 for OR, 2 for AND
+	Tags map[string][]string `json:"tags"`
+}
+
+// Implement required interfaces
+
+func (azureMonitor *AzureMonitor) SetLocationProfileID(locationProfileID string) {
+}
+
+func (azureMonitor *AzureMonitor) GetLocationProfileID() string {
+	return ""
+}
+
+func (azureMonitor *AzureMonitor) SetNotificationProfileID(notificationProfileID string) {
+	azureMonitor.NotificationProfileID = notificationProfileID
+}
+
+func (azureMonitor *AzureMonitor) GetNotificationProfileID() string {
+	return azureMonitor.NotificationProfileID
+}
+
+func (azureMonitor *AzureMonitor) SetUserGroupIDs(userGroupIDs []string) {
+	azureMonitor.UserGroupIDs = userGroupIDs
+}
+
+func (azureMonitor *AzureMonitor) GetUserGroupIDs() []string {
+	return azureMonitor.UserGroupIDs
+}
+
+func (azureMonitor *AzureMonitor) String() string {
+	return ToString(azureMonitor)
+}

--- a/docs/resources/azure_monitor.md
+++ b/docs/resources/azure_monitor.md
@@ -1,0 +1,129 @@
+---
+layout: "site24x7"
+page_title: "Site24x7: site24x7_azure_monitor"
+sidebar_current: "docs-site24x7-resource-azure-monitor"
+description: |-
+  Create and manage Azure monitors in Site24x7.
+---
+
+# Resource: site24x7_azure_monitor
+
+Use this resource to create, update and delete Azure monitors in Site24x7.
+
+## Example Usage
+
+```hcl
+terraform {
+  required_providers {
+    site24x7 = {
+      source = "site24x7/site24x7"
+      # Update the latest version from https://registry.terraform.io/providers/site24x7/site24x7/latest
+    }
+  }
+}
+
+provider "site24x7" {
+  oauth2_client_id     = "<SITE24X7_OAUTH2_CLIENT_ID>"
+  oauth2_client_secret = "<SITE24X7_OAUTH2_CLIENT_SECRET>"
+  oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
+  data_center          = "US"
+  retry_max_wait       = 30
+  max_retries          = 4
+}
+
+resource "site24x7_azure_monitor" "example" {
+  // (Required) Display name for the Azure monitor
+  display_name = "My Azure Monitor Terraform"
+
+  // (Required) Azure Entra ID (Tenant ID)
+  tenant_id = "<AZURE_ENTRA_TENANT_ID>"
+
+  // (Required) Application (client) ID from Azure App Registration
+  client_id = "<AZURE_APP_REGISTRATION_CLIENT_ID>"
+
+  // (Security recommendation - It is always best practice to store your credentials in a Vault of your choice.)
+  // (Required) Application client secret from Azure App Registration
+  client_secret = "<AZURE_APP_REGISTRATION_CLIENT_SECRET>"
+
+  // (Required) Monitor type should be "AZURE"
+  type = "AZURE"
+
+  // (Required) Azure services to discover. Format: ["<ResourceProvider>/<ResourceType>"]
+  services = ["Microsoft.Compute/virtualMachines"]
+
+  // (Required) Set to 0 for Azure Account-based discovery, 1 for Management Group-based discovery
+  management_group_reg = 0
+
+  // (Optional) Discovery interval in minutes
+  discovery_interval = "30"
+
+  // (Optional) Automatically add newly discovered Azure subscriptions
+  auto_add_subscription = 1
+
+  // (Optional) Name of the notification profile to be associated with the monitor.
+  // Either specify notification_profile_id or notification_profile_name.
+  notification_profile_id = "Terraform Profile"
+
+  // (Optional) List of user group IDs to be notified on down.
+  user_group_ids = ["123"]
+
+  // (Optional) Threshold profile to be associated with the monitor.
+  threshold_profile_id = "azure threshold profile"
+
+  // (Optional) Include Azure resources with matching tags. Format: "key:value"
+  include_tags = [
+    "Environment:Production",
+    "Team:DevOps"
+  ]
+
+  // (Optional) Exclude Azure resources with matching tags. Format: "key:value"
+  exclude_tags = [
+    "Environment:Test",
+    "Owner:External"
+  ]
+}
+Attributes Reference
+Required
+display_name (String) Display name for the Azure monitor.
+
+tenant_id (String) Azure Entra ID (Tenant ID).
+
+client_id (String) Application (client) ID from Azure App Registration.
+
+client_secret (String) Client secret from Azure App Registration.
+
+type (String) Monitor type. Must be "AZURE".
+
+services (List of String) Azure services to discover. Format: ["<ResourceProvider>/<ResourceType>"]
+
+management_group_reg (Number) Set to 0 for Azure Account-based discovery, 1 for Management Group-based discovery.
+
+Optional
+discovery_interval (String) Rediscovery polling interval in minutes.
+
+auto_add_subscription (Number) Automatically add newly discovered subscriptions. Set to 1 to enable.
+
+notification_profile_id (String) Notification profile ID to associate with the monitor. If omitted, the first profile from the /api/notification_profiles endpoint will be used.
+
+notification_profile_name (String) Notification profile name to associate with the monitor. Supports partial or full name match.
+
+user_group_ids (List of String) List of user group IDs to be notified on down. If omitted, the first group from the /api/user_groups endpoint will be used.
+
+user_group_names (List of String) List of user group names to be notified on down. Supports partial or full name match.
+
+threshold_profile_id (String) Threshold profile ID to associate with the monitor. If omitted, the first profile for the AZURE monitor type will be used.
+
+tag_ids (List of String) List of tag IDs to be associated to the monitor. Either use tag_ids or tag_names.
+
+tag_names (List of String) List of tag names to be associated. Supports partial or full name match. Either use tag_names or tag_ids.
+
+third_party_service_ids (List of String) List of Third Party Service IDs to associate to the monitor.
+
+include_tags (List of String) Include resources with these tags. Format: "key:value".
+
+exclude_tags (List of String) Exclude resources with these tags. Format: "key:value".
+
+Output
+id (String) The ID of this resource.
+
+Refer API documentation https://www.site24x7.com/help/api/#azure-monitor for more information about attributes.

--- a/examples/azure_monitor_us.tf
+++ b/examples/azure_monitor_us.tf
@@ -1,0 +1,108 @@
+terraform {
+  required_providers {
+    site24x7 = {
+      source  = "site24x7/site24x7"
+      # Update the latest version from https://registry.terraform.io/providers/site24x7/site24x7/latest 
+      
+    }
+  }
+}
+
+provider "site24x7" {
+  // (Security recommendation - It is always best practice to store your credentials in a Vault of your choice.)
+	// (Required) The client ID will be looked up in the SITE24X7_OAUTH2_CLIENT_ID
+	// environment variable if the attribute is empty or omitted.
+	oauth2_client_id = "<SITE24X7_OAUTH2_CLIENT_ID>"
+
+  // (Security recommendation - It is always best practice to store your credentials in a Vault of your choice.)
+	// (Required) The client secret will be looked up in the SITE24X7_OAUTH2_CLIENT_SECRET
+	// environment variable if the attribute is empty or omitted.
+	oauth2_client_secret = "<SITE24X7_OAUTH2_CLIENT_SECRET>"
+    
+  // (Security recommendation - It is always best practice to store your credentials in a Vault of your choice.)
+	// (Required) The refresh token will be looked up in the SITE24X7_OAUTH2_REFRESH_TOKEN
+	// environment variable if the attribute is empty or omitted.
+	oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
+    
+	// (Required) Specify the data center from which you have obtained your
+	// OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
+	data_center = "US"
+  
+	// (Optional) The maximum time to wait in seconds before retrying failed Site24x7 API
+	// requests. This is the upper limit for the wait duration with exponential
+	// backoff.
+	retry_max_wait = 30
+  
+	// (Optional) Maximum number of Site24x7 API request retries to perform until giving up.
+	max_retries = 4
+  
+  
+}
+
+resource "site24x7_azure_monitor" "example" {
+  // (Required) Display name for the Azure monitor
+  display_name            = "My Azure Monitor Terraform"
+
+  // (Required) Azure Entra ID (Tenant ID)
+  tenant_id               = "<AZURE_ENTRA_TENANT_ID>"
+
+  // (Required) Application (client) ID from Azure App Registration
+  client_id               = "<AZURE_APP_REGISTRATION_CLIENT_ID>"
+
+  // (Security recommendation - It is always best practice to store your credentials in a Vault of your choice.)
+  // (Required) Application client secret from Azure App Registration
+  client_secret           = "<AZURE_APP_REGISTRATION_CLIENT_SECRET>"
+
+  // (Required) Monitor type should be "AZURE"
+  type                    = "AZURE"
+
+  // (Required) Azure services to discover. Format: ["<ResourceProvider>/<ResourceType>"]
+  // Example: ["Microsoft.Compute/virtualMachines"]
+  services                = ["Microsoft.Compute/virtualMachines"] # Modify with actual service type IDs you want to discover
+
+  // (Required) Set to 0 for Azure Account-based discovery, 1 for Management Group-based discovery
+  management_group_reg    = 0        # Use 0 for Azure Account, 1 for Management Group
+
+  // (Optional) AZURE discover interval in minutes
+  discovery_interval      = "30"     # Optional: Discovery interval in minutes
+
+  // (Optional) Automatically add newly discovered Azure subscriptions
+  auto_add_subscription   = 1        # Optionally set to 1 to auto-add subscriptions
+
+  // (Optional) Name of the notification profile that has to be associated with the monitor.
+  // Profile name matching works for both exact and partial match.
+  // Either specify notification_profile_id or notification_profile_name.
+  // If notification_profile_id and notification_profile_name are omitted,
+  // the first profile returned by the /api/notification_profiles endpoint
+  // (https://www.site24x7.com/help/api/#list-notification-profiles) will be
+  // used.
+  notification_profile_id = "Terraform Profile"
+
+  // (Optional) List if user group IDs to be notified on down. 
+  // Either specify user_group_ids or user_group_names. If omitted, the
+  // first user group returned by the /api/user_groups endpoint
+  // (https://www.site24x7.com/help/api/#list-of-all-user-groups) will be used.
+  user_group_ids          = ["123"]
+
+  // (Optional) Threshold profile to be associated with the monitor. If
+  // omitted, the first profile returned by the /api/threshold_profiles
+  // endpoint for the AZURE monitor type (https://www.site24x7.com/help/api/#list-threshold-profiles) will
+  // be used.
+  threshold_profile_id    = "azure threshold profile"
+
+  // (Optional) Include Azure resources with matching tags.
+  // Format: "key:value"
+  include_tags = [
+    "Environment:Production",
+    "Team:DevOps"
+  ]
+
+  // (Optional) Exclude Azure resources with matching tags.
+  // Format: "key:value"
+  exclude_tags = [
+    "Environment:Test",
+    "Owner:External"
+  ]
+
+
+}

--- a/fake/client.go
+++ b/fake/client.go
@@ -19,6 +19,7 @@ type Client struct {
 	FakeSubgroups                     *fake.Subgroups
 	FakeTags                          *fake.Tags
 	FakeAmazonMonitors                *fake.AmazonMonitors
+	FakeAzureMonitors                 *fake.AzureMonitors
 	FakeWebsiteMonitors               *fake.WebsiteMonitors
 	FakeWebPageSpeedMonitors          *fake.WebPageSpeedMonitors
 	FakeSSLMonitors                   *fake.SSLMonitors
@@ -64,6 +65,7 @@ func NewClient() *Client {
 		FakeSubgroups:                     &fake.Subgroups{},
 		FakeTags:                          &fake.Tags{},
 		FakeAmazonMonitors:                &fake.AmazonMonitors{},
+		FakeAzureMonitors:                 &fake.AzureMonitors{},
 		FakeSSLMonitors:                   &fake.SSLMonitors{},
 		FakeCronMonitors:                  &fake.CronMonitors{},
 		FakeHeartbeatMonitors:             &fake.HeartbeatMonitors{},

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -80,6 +80,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"site24x7_amazon_monitor":                  monitors.ResourceSite24x7AmazonMonitor(),
 			"site24x7_gcp_monitor":                     monitors.ResourceSite24x7GCPMonitor(),
+			"site24x7_azure_monitor":                   monitors.ResourceSite24x7AzureMonitor(),
 			"site24x7_website_monitor":                 monitors.ResourceSite24x7WebsiteMonitor(),
 			"site24x7_web_page_speed_monitor":          monitors.ResourceSite24x7WebPageSpeedMonitor(),
 			"site24x7_ssl_monitor":                     monitors.ResourceSite24x7SSLMonitor(),

--- a/site24x7/client.go
+++ b/site24x7/client.go
@@ -102,6 +102,7 @@ type Client interface {
 	RestApiTransactionMonitors() monitors.RestApiTransactionMonitors
 	AmazonMonitors() monitors.AmazonMonitors
 	GCPMonitors() monitors.GCPMonitors
+	AzureMonitors() monitors.AzureMonitors
 	NotificationProfiles() endpoints.NotificationProfiles
 	ThresholdProfiles() endpoints.ThresholdProfiles
 	Users() endpoints.Users
@@ -192,6 +193,11 @@ func (c *client) AmazonMonitors() monitors.AmazonMonitors {
 // GCPMonitors implements Client.
 func (c *client) GCPMonitors() monitors.GCPMonitors {
 	return monitors.NewGCPMonitors(c.restClient)
+}
+
+// AzureMonitors implements Client.
+func (c *client) AzureMonitors() monitors.AzureMonitors {
+	return monitors.NewAzureMonitors(c.restClient)
 }
 
 // WebsiteMonitors implements Client.

--- a/site24x7/monitors/azure.go
+++ b/site24x7/monitors/azure.go
@@ -1,0 +1,303 @@
+package monitors
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/site24x7/terraform-provider-site24x7/api"
+	apierrors "github.com/site24x7/terraform-provider-site24x7/api/errors"
+	"github.com/site24x7/terraform-provider-site24x7/site24x7"
+)
+
+var AzureMonitorSchema = map[string]*schema.Schema{
+	"display_name": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Display name for the Azure monitor.",
+	},
+	"tenant_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "The Tenant ID associated with the Microsoft Entra ID.",
+	},
+	"client_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "The Client ID for the Azure Service Principal.",
+	},
+	"client_secret": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Sensitive:   true,
+		Description: "The Client Secret associated with the Azure Service Principal.",
+	},
+	"type": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Type of the monitor (should be AZURE).",
+	},
+	"services": {
+		Type:        schema.TypeList,
+		Elem:        &schema.Schema{Type: schema.TypeString},
+		Required:    true,
+		Description: "List of Azure service types to be discovered.",
+	},
+	"management_group_reg": {
+		Type:        schema.TypeInt,
+		Required:    true,
+		Description: "Use 0 for Azure Account, 1 for Management Group.",
+	},
+	"notification_profile_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Notification profile associated with the monitor.",
+	},
+	"user_group_ids": {
+		Type:        schema.TypeList,
+		Elem:        &schema.Schema{Type: schema.TypeString},
+		Required:    true,
+		Description: "User group IDs to be notified during outages.",
+	},
+	"threshold_profile_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Threshold profile ID to be associated with the monitor.",
+	},
+	"discovery_interval": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Rediscovery interval (e.g., 30, 60, 360, etc.).",
+	},
+	"auto_add_subscription": {
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Description: "Automatically add newly-added subscriptions (1 for Yes, 0 for No).",
+	},
+	"azure_exclude_tags": {
+		Type:        schema.TypeMap,
+		Optional:    true,
+		Description: "Tags to exclude Azure resources from discovery.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Required: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeList,
+						Elem: &schema.Schema{Type: schema.TypeString},
+					},
+				},
+			},
+		},
+	},
+	"azure_include_tags": {
+		Type:        schema.TypeMap,
+		Optional:    true,
+		Description: "Tags to include Azure resources in discovery.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Required: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeList,
+						Elem: &schema.Schema{Type: schema.TypeString},
+					},
+				},
+			},
+		},
+	},
+}
+
+func ResourceSite24x7AzureMonitor() *schema.Resource {
+	return &schema.Resource{
+		Create: azureMonitorCreate,
+		Read:   azureMonitorRead,
+		Update: azureMonitorUpdate,
+		Delete: azureMonitorDelete,
+		Exists: azureMonitorExists,
+		Schema: AzureMonitorSchema,
+	}
+}
+
+func azureMonitorCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(site24x7.Client)
+	monitor, err := resourceDataToAzureMonitor(d, client)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] Azure Monitor payload: %+v", monitor)
+
+	azureMonitor, err := client.AzureMonitors().Create(monitor)
+	if err != nil {
+		return err
+	}
+	d.SetId(azureMonitor.MonitorID)
+	return nil
+}
+
+func azureMonitorRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(site24x7.Client)
+	azureMonitor, err := client.AzureMonitors().Get(d.Id())
+	if err != nil {
+		return err
+	}
+	updateAzureMonitorResourceData(d, azureMonitor)
+	return nil
+}
+
+func azureMonitorUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(site24x7.Client)
+	monitor, err := resourceDataToAzureMonitor(d, client)
+	if err != nil {
+		return err
+	}
+	azureMonitor, err := client.AzureMonitors().Update(monitor)
+	if err != nil {
+		return err
+	}
+	d.SetId(azureMonitor.MonitorID)
+	return nil
+}
+
+func azureMonitorDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(site24x7.Client)
+	err := client.AzureMonitors().Delete(d.Id())
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func azureMonitorExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(site24x7.Client)
+	_, err := client.AzureMonitors().Get(d.Id())
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func expandAzureTagCondition(input map[string]interface{}) *api.AzureTagCondition {
+	if input == nil {
+		return nil
+	}
+
+	// Guard against missing or nil values
+	typeVal, typeOk := input["type"]
+	tagsVal, tagsOk := input["tags"]
+
+	if !typeOk || !tagsOk {
+		return nil // or handle the error appropriately
+	}
+
+	// Ensure type is an int
+	typeInt, ok := typeVal.(int)
+	if !ok {
+		// Log error or handle the unexpected type
+		return nil // or return an error if necessary
+	}
+
+	tagCondition := &api.AzureTagCondition{
+		Type: typeInt,
+		Tags: make(map[string][]string),
+	}
+
+	// Check if 'tags' is of the correct type
+	rawTags, ok := tagsVal.(map[string]interface{})
+	if !ok {
+		// Handle the unexpected type
+		return tagCondition // or handle accordingly
+	}
+
+	for k, v := range rawTags {
+		interfaceList, ok := v.([]interface{})
+		if !ok {
+			continue // or handle the invalid type
+		}
+		strList := make([]string, len(interfaceList))
+		for i, val := range interfaceList {
+			strList[i] = val.(string)
+		}
+		tagCondition.Tags[k] = strList
+	}
+
+	return tagCondition
+}
+
+func flattenAzureTagCondition(condition *api.AzureTagCondition) map[string]interface{} {
+	if condition == nil {
+		return nil
+	}
+
+	tags := make(map[string]interface{})
+	for k, v := range condition.Tags {
+		strList := make([]interface{}, len(v))
+		for i, s := range v {
+			strList[i] = s
+		}
+		tags[k] = strList
+	}
+
+	return map[string]interface{}{
+		"type": condition.Type,
+		"tags": tags,
+	}
+}
+
+func resourceDataToAzureMonitor(d *schema.ResourceData, client site24x7.Client) (*api.AzureMonitor, error) {
+	var userGroupIDs []string
+	for _, id := range d.Get("user_group_ids").([]interface{}) {
+		if id != nil {
+			userGroupIDs = append(userGroupIDs, id.(string))
+		}
+	}
+
+	var services []string
+	for _, v := range d.Get("services").([]interface{}) {
+		if serviceType, ok := v.(string); ok {
+			services = append(services, serviceType)
+		}
+	}
+
+	monitor := &api.AzureMonitor{
+		MonitorID:             d.Id(),
+		DisplayName:           d.Get("display_name").(string),
+		TenantID:              d.Get("tenant_id").(string),
+		ClientID:              d.Get("client_id").(string),
+		ClientSecret:          d.Get("client_secret").(string),
+		Type:                  d.Get("type").(string),
+		Services:              services,
+		ManagementGroupReg:    d.Get("management_group_reg").(int),
+		NotificationProfileID: d.Get("notification_profile_id").(string),
+		UserGroupIDs:          userGroupIDs,
+		ThresholdProfileID:    d.Get("threshold_profile_id").(string),
+		DiscoveryInterval:     d.Get("discovery_interval").(string),
+		AutoAddSubscription:   d.Get("auto_add_subscription").(int),
+		AzureExcludeTags:      expandAzureTagCondition(d.Get("azure_exclude_tags").(map[string]interface{})),
+		AzureIncludeTags:      expandAzureTagCondition(d.Get("azure_include_tags").(map[string]interface{})),
+	}
+	return monitor, nil
+}
+
+func updateAzureMonitorResourceData(d *schema.ResourceData, m *api.AzureMonitor) {
+	d.Set("display_name", m.DisplayName)
+	d.Set("type", m.Type)
+	d.Set("services", m.Services)
+	d.Set("management_group_reg", m.ManagementGroupReg)
+	d.Set("notification_profile_id", m.NotificationProfileID)
+	d.Set("user_group_ids", m.UserGroupIDs)
+	d.Set("threshold_profile_id", m.ThresholdProfileID)
+	d.Set("discovery_interval", m.DiscoveryInterval)
+	d.Set("auto_add_subscription", m.AutoAddSubscription)
+	d.Set("azure_exclude_tags", flattenAzureTagCondition(m.AzureExcludeTags))
+	d.Set("azure_include_tags", flattenAzureTagCondition(m.AzureIncludeTags))
+}

--- a/site24x7/monitors/azure_test.go
+++ b/site24x7/monitors/azure_test.go
@@ -1,0 +1,133 @@
+package monitors
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/site24x7/terraform-provider-site24x7/api"
+	apierrors "github.com/site24x7/terraform-provider-site24x7/api/errors"
+	"github.com/site24x7/terraform-provider-site24x7/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAzureMonitorCreate(t *testing.T) {
+	d := azureTestResourceData(t)
+	c := fake.NewClient()
+
+	a := &api.AzureMonitor{
+		DisplayName:           "Test Azure Monitor",
+		TenantID:              "tenant-123",
+		ClientID:              "client-abc",
+		ClientSecret:          "secret-key",
+		Type:                  "AZURE",
+		Services:              []string{"vm", "sql"},
+		ManagementGroupReg:    0,
+		NotificationProfileID: "notif-789",
+		UserGroupIDs:          []string{"user1", "user2"},
+		ThresholdProfileID:    "threshold-456",
+		DiscoveryInterval:     "30",
+		AutoAddSubscription:   1,
+	}
+
+	c.FakeAzureMonitors.On("Create", a).Return(a, nil).Once()
+
+	require.NoError(t, azureMonitorCreate(d, c))
+
+	c.FakeAzureMonitors.On("Create", a).Return(nil, apierrors.NewStatusError(500, "error")).Once()
+	err := azureMonitorCreate(d, c)
+	assert.Equal(t, apierrors.NewStatusError(500, "error"), err)
+}
+
+func TestAzureMonitorUpdate(t *testing.T) {
+	d := azureTestResourceData(t)
+	d.SetId("monitor-123")
+
+	c := fake.NewClient()
+	a := &api.AzureMonitor{
+		MonitorID:             "monitor-123",
+		DisplayName:           "Test Azure Monitor",
+		TenantID:              "tenant-123",
+		ClientID:              "client-abc",
+		ClientSecret:          "secret-key",
+		Type:                  "AZURE",
+		Services:              []string{"vm", "sql"},
+		ManagementGroupReg:    0,
+		NotificationProfileID: "notif-789",
+		UserGroupIDs:          []string{"user1", "user2"},
+		ThresholdProfileID:    "threshold-456",
+		DiscoveryInterval:     "30",
+		AutoAddSubscription:   1,
+	}
+
+	c.FakeAzureMonitors.On("Update", a).Return(a, nil).Once()
+	require.NoError(t, azureMonitorUpdate(d, c))
+
+	c.FakeAzureMonitors.On("Update", a).Return(nil, apierrors.NewStatusError(500, "error")).Once()
+	err := azureMonitorUpdate(d, c)
+	assert.Equal(t, apierrors.NewStatusError(500, "error"), err)
+}
+
+func TestAzureMonitorRead(t *testing.T) {
+	d := azureTestResourceData(t)
+	d.SetId("monitor-123")
+
+	c := fake.NewClient()
+	c.FakeAzureMonitors.On("Get", "monitor-123").Return(&api.AzureMonitor{}, nil).Once()
+	require.NoError(t, azureMonitorRead(d, c))
+
+	c.FakeAzureMonitors.On("Get", "monitor-123").Return(nil, apierrors.NewStatusError(500, "error")).Once()
+	err := azureMonitorRead(d, c)
+	assert.Equal(t, apierrors.NewStatusError(500, "error"), err)
+}
+
+func TestAzureMonitorDelete(t *testing.T) {
+	d := azureTestResourceData(t)
+	d.SetId("monitor-123")
+
+	c := fake.NewClient()
+	c.FakeAzureMonitors.On("Delete", "monitor-123").Return(nil).Once()
+	require.NoError(t, azureMonitorDelete(d, c))
+
+	c.FakeAzureMonitors.On("Delete", "monitor-123").Return(apierrors.NewStatusError(404, "not found")).Once()
+	require.NoError(t, azureMonitorDelete(d, c))
+}
+
+func TestAzureMonitorExists(t *testing.T) {
+	d := azureTestResourceData(t)
+	d.SetId("monitor-123")
+
+	c := fake.NewClient()
+	c.FakeAzureMonitors.On("Get", "monitor-123").Return(&api.AzureMonitor{}, nil).Once()
+
+	exists, err := azureMonitorExists(d, c)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	c.FakeAzureMonitors.On("Get", "monitor-123").Return(nil, apierrors.NewStatusError(404, "not found")).Once()
+	exists, err = azureMonitorExists(d, c)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	c.FakeAzureMonitors.On("Get", "monitor-123").Return(nil, apierrors.NewStatusError(500, "error")).Once()
+	exists, err = azureMonitorExists(d, c)
+	assert.Equal(t, apierrors.NewStatusError(500, "error"), err)
+	assert.False(t, exists)
+}
+
+func azureTestResourceData(t *testing.T) *schema.ResourceData {
+	return schema.TestResourceDataRaw(t, AzureMonitorSchema, map[string]interface{}{
+		"display_name":            "Test Azure Monitor",
+		"tenant_id":               "tenant-123",
+		"client_id":               "client-abc",
+		"client_secret":           "secret-key",
+		"type":                    "AZURE",
+		"services":                []interface{}{"vm", "sql"},
+		"management_group_reg":    0,
+		"notification_profile_id": "notif-789",
+		"user_group_ids":          []interface{}{"user1", "user2"},
+		"threshold_profile_id":    "threshold-456",
+		"discovery_interval":      "30",
+		"auto_add_subscription":   1,
+	})
+}


### PR DESCRIPTION
**🚀 What's Added:**
 New Resource Support: Introduced support for managing Azure Monitors in Site24x7 via Terraform.

**Core Additions:**

site24x7_azure_monitor resource added to the provider.

New struct AzureMonitor added to monitor_types.go.

API client interface and implementation (AzureMonitors) with full CRUD support.

Tests for Azure monitor operations using mock client (azure_impl_test.go).

Terraform schema definition in monitors/azure.go.

Documentation (azure_monitor.md) and example usage (examples/azure_monitor_us.tf) included.

Registered resource in provider.go, and mock support added in fake/client.go.

**📄 README:**
Azure Monitor has been added to the list of supported monitor types in the README.