### PR TITLE
Finish implementation of fake.Client

### DIFF
--- a/api/endpoints/fake/aws_external_id.go
+++ b/api/endpoints/fake/aws_external_id.go
@@ -2,7 +2,10 @@ package fake
 
 import (
 	"github.com/site24x7/terraform-provider-site24x7/api"
+	"github.com/site24x7/terraform-provider-site24x7/api/endpoints/aws"
 )
+
+var _ aws.AWSExternalID = &AWSExternalID{}
 
 // AWSExternalID is a fake implementation of the aws.AWSExternalID interface.
 type AWSExternalID struct{}

--- a/api/endpoints/fake/device_key.go
+++ b/api/endpoints/fake/device_key.go
@@ -1,0 +1,24 @@
+package fake
+
+import (
+	"github.com/site24x7/terraform-provider-site24x7/api"
+	"github.com/site24x7/terraform-provider-site24x7/api/endpoints/common"
+	"github.com/stretchr/testify/mock"
+)
+
+// Ensuring the mock struct implements the interface
+var _ common.DeviceKey = &DeviceKey{}
+
+// DeviceKey is the mock implementation of the DeviceKey interface
+type DeviceKey struct {
+	mock.Mock
+}
+
+// Get retrieves a DeviceKey
+func (c *DeviceKey) Get() (*api.DeviceKey, error) {
+	args := c.Called()
+	if obj, ok := args.Get(0).(*api.DeviceKey); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}

--- a/api/endpoints/fake/dnsserver_monitors.go
+++ b/api/endpoints/fake/dnsserver_monitors.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-var _ monitors.WebsiteMonitors = &WebsiteMonitors{}
+var _ monitors.DNSServerMonitors = &DNSServerMonitors{}
 
 type DNSServerMonitors struct {
 	mock.Mock

--- a/api/endpoints/fake/gcp.go
+++ b/api/endpoints/fake/gcp.go
@@ -1,0 +1,60 @@
+package fake
+
+import (
+	"github.com/site24x7/terraform-provider-site24x7/api"
+	"github.com/site24x7/terraform-provider-site24x7/api/endpoints/monitors"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ monitors.GCPMonitors = &GCPMonitors{}
+
+type GCPMonitors struct {
+	mock.Mock
+}
+
+func (e *GCPMonitors) Get(monitorID string) (*api.GCPMonitor, error) {
+	args := e.Called(monitorID)
+	if obj, ok := args.Get(0).(*api.GCPMonitor); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *GCPMonitors) Create(monitor *api.GCPMonitor) (*api.GCPMonitor, error) {
+	args := e.Called(monitor)
+	if obj, ok := args.Get(0).(*api.GCPMonitor); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *GCPMonitors) Update(monitor *api.GCPMonitor) (*api.GCPMonitor, error) {
+	args := e.Called(monitor)
+	if obj, ok := args.Get(0).(*api.GCPMonitor); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *GCPMonitors) Delete(monitorID string) error {
+	args := e.Called(monitorID)
+	return args.Error(0)
+}
+
+func (e *GCPMonitors) List() ([]*api.GCPMonitor, error) {
+	args := e.Called()
+	if obj, ok := args.Get(0).([]*api.GCPMonitor); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *GCPMonitors) Activate(monitorID string) error {
+	args := e.Called(monitorID)
+	return args.Error(0)
+}
+
+func (e *GCPMonitors) Suspend(monitorID string) error {
+	args := e.Called(monitorID)
+	return args.Error(0)
+}

--- a/api/endpoints/fake/schedule_report.go
+++ b/api/endpoints/fake/schedule_report.go
@@ -2,8 +2,11 @@ package fake
 
 import (
 	"github.com/site24x7/terraform-provider-site24x7/api"
+	"github.com/site24x7/terraform-provider-site24x7/api/endpoints/common"
 	"github.com/stretchr/testify/mock"
 )
+
+var _ common.ScheduleReport = &ScheduleReport{}
 
 type ScheduleReport struct {
 	mock.Mock

--- a/fake/client.go
+++ b/fake/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/site24x7/terraform-provider-site24x7/api/endpoints/fake"
 	"github.com/site24x7/terraform-provider-site24x7/api/endpoints/integration"
 	"github.com/site24x7/terraform-provider-site24x7/api/endpoints/monitors"
+	"github.com/site24x7/terraform-provider-site24x7/api/endpoints/msp"
 )
 
 // Client is an implementation of site24x7.Client that stubs out all endpoints
@@ -56,6 +57,8 @@ type Client struct {
 	FakeBusinesshour                  *fake.BusinessHour
 	FakeCustomer                      *fake.Customer
 	FakeAWSExternalID                 *fake.AWSExternalID
+	FakeGCPMonitors                   *fake.GCPMonitors
+	FakeDeviceKey                     *fake.DeviceKey
 }
 
 // NewClient creates a new fake site24x7 API client.
@@ -105,6 +108,8 @@ func NewClient() *Client {
 		FakeBusinesshour:                  &fake.BusinessHour{},
 		FakeCustomer:                      &fake.Customer{},
 		FakeAWSExternalID:                 &fake.AWSExternalID{},
+		FakeGCPMonitors:                   &fake.GCPMonitors{},
+		FakeDeviceKey:                     &fake.DeviceKey{},
 	}
 }
 
@@ -174,7 +179,7 @@ func (c *Client) SOAPMonitors() monitors.SOAPMonitors {
 }
 
 // WebTransactionBrowserMonitors implements Client.
-func (c *Client) WebTransactionBrowserMonitor() monitors.WebTransactionBrowserMonitors {
+func (c *Client) WebTransactionBrowserMonitors() monitors.WebTransactionBrowserMonitors {
 	return c.FakeWebTransactionBrowserMonitors
 }
 
@@ -311,12 +316,27 @@ func (c *Client) MSP() endpoints.MSP {
 	return c.FakeMSP
 }
 
-// RestApiMonitors implements Client.
-func (c *Client) credentialProfile() common.CredentialProfile {
+// CredentialProfile implements Client.
+func (c *Client) CredentialProfile() common.CredentialProfile {
 	return c.FakeCredentialProfile
 }
 
 // Business hour implements Client.
 func (c *Client) BusinessHour() common.BusinessHourService {
 	return c.FakeBusinesshour
+}
+
+// Customers implements implements Client.
+func (c *Client) Customers() msp.Customers {
+	return c.FakeCustomer
+}
+
+// DeviceKey implements Client.
+func (c *Client) DeviceKey() common.DeviceKey {
+	return c.FakeDeviceKey
+}
+
+// GCPMonitors implements Client.
+func (c *Client) GCPMonitors() monitors.GCPMonitors {
+	return c.FakeGCPMonitors
 }

--- a/fake/client.go
+++ b/fake/client.go
@@ -326,7 +326,7 @@ func (c *Client) BusinessHour() common.BusinessHourService {
 	return c.FakeBusinesshour
 }
 
-// Customers implements implements Client.
+// Customers implements Client.
 func (c *Client) Customers() msp.Customers {
 	return c.FakeCustomer
 }

--- a/fake/client_test.go
+++ b/fake/client_test.go
@@ -5,10 +5,14 @@ import (
 	"testing"
 
 	"github.com/site24x7/terraform-provider-site24x7/api"
+	"github.com/site24x7/terraform-provider-site24x7/site24x7"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// make sure whole interface is implemented
+var _ site24x7.Client = &Client{}
 
 func TestClientMonitorsCreate(t *testing.T) {
 	c := NewClient()


### PR DESCRIPTION
Make sure unit tests can actually use fake.Client to run tests.

Bunch of tests now fail with and do not even run any tests:
```
panic: interface conversion: *fake.Client is not site24x7.Client: missing method CredentialProfile [recovered, repanicked]
```

Updating several Fake/Mock implementation to make sure whole interface is implemented.

Adding `GCPMonitor` and `DeviceKey` mocks.

Add check to make sure site24x7 interface is implemented fully.