### PR TITLE
Azure monitor addition tag condition issue identified and resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A terraform provider for managing the following resources in Site24x7:
 - User - [site24x7_user](examples/user_us.tf) ([Site24x7 User API doc](https://www.site24x7.com/help/api/#users))
 - Tag - [site24x7_tag](examples/tag_us.tf) ([Site24x7 Tag API doc](https://www.site24x7.com/help/api/#tags))
 - Schedule Maintenance - [site24x7_schedule_maintenance](examples/schedule_maintenance_us.tf) ([Site24x7 Schedule Maintenance API doc](https://www.site24x7.com/help/api/#schedule-maintenances))
+- Schedule Report - [site24x7_schedule_report](examples/schedule_report_eu.tf) ([Site24x7 Schedule Report API doc](https://www.site24x7.com/help/api/#schedule-reports))
 - Credential Profile - [site24x7_credential_profile](examples/credential_profiles_us.tf) ([Credential Profile API doc](https://www.site24x7.com/help/api/#credential-profiles))
 
 #### Integrations

--- a/api/monitor_types.go
+++ b/api/monitor_types.go
@@ -1,5 +1,10 @@
 package api
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 type Site24x7Monitor interface {
 	SetLocationProfileID(notificationProfileID string)
 	GetLocationProfileID() string
@@ -1263,6 +1268,35 @@ type AzureMonitor struct {
 type AzureTagCondition struct {
 	Type int                 `json:"type"` // 1 for OR, 2 for AND
 	Tags map[string][]string `json:"tags"`
+}
+
+// UnmarshalJSON implements custom JSON unmarshalling for AzureTagCondition.
+// The Site24x7 API returns azure_exclude_tags and azure_include_tags as JSON-encoded
+// strings (e.g., "{\"type\":1,\"tags\":{...}}") rather than JSON objects. This method
+// handles both the string-wrapped format from the API and direct JSON objects.
+func (a *AzureTagCondition) UnmarshalJSON(data []byte) error {
+	// Alias type to avoid infinite recursion when calling json.Unmarshal
+	type Alias AzureTagCondition
+
+	// First, try unmarshalling directly as an object
+	var direct Alias
+	if err := json.Unmarshal(data, &direct); err == nil {
+		*a = AzureTagCondition(direct)
+		return nil
+	}
+
+	// If that fails, try treating data as a JSON string containing JSON
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("azure_tag_condition: cannot unmarshal %s", string(data))
+	}
+
+	var fromString Alias
+	if err := json.Unmarshal([]byte(s), &fromString); err != nil {
+		return err
+	}
+	*a = AzureTagCondition(fromString)
+	return nil
 }
 
 // Implement required interfaces

--- a/examples/schedule_summary_report_eu.tf
+++ b/examples/schedule_summary_report_eu.tf
@@ -1,0 +1,80 @@
+terraform {
+  required_providers {
+    site24x7 = {
+      source  = "site24x7.com/site24x7/site24x7"
+      version = "1.0.0"
+    }
+  }
+}
+
+
+// Authentication API doc - https://www.site24x7.com/help/api/#authentication
+provider "site24x7" {
+  // (Required) The client ID will be looked up in the SITE24X7_OAUTH2_CLIENT_ID
+  // environment variable if the attribute is empty or omitted.
+  oauth2_client_id = "<SITE24X7_OAUTH2_CLIENT_ID>"
+
+  // (Required) The client secret will be looked up in the SITE24X7_OAUTH2_CLIENT_SECRET
+  // environment variable if the attribute is empty or omitted.
+  oauth2_client_secret = "<SITE24X7_OAUTH2_CLIENT_SECRET>"
+
+  // (Required) The refresh token will be looked up in the SITE24X7_OAUTH2_REFRESH_TOKEN
+  // environment variable if the attribute is empty or omitted.
+  oauth2_refresh_token = "<SITE24X7_OAUTH2_REFRESH_TOKEN>"
+
+  // (Required) Specify the data center from which you have obtained your
+  // OAuth client credentials and refresh token. It can be (US/EU/IN/AU/CN/JP/CA).
+  data_center = "EU"
+
+  // (Optional) ZAAID of the customer under a MSP or BU
+  # zaaid = "1234"
+
+  // (Optional) The minimum time to wait in seconds before retrying failed Site24x7 API requests.
+  retry_min_wait = 1
+
+  // (Optional) The maximum time to wait in seconds before retrying failed Site24x7 API
+  // requests. This is the upper limit for the wait duration with exponential
+  // backoff.
+  retry_max_wait = 30
+
+  // (Optional) Maximum number of Site24x7 API request retries to perform until giving up.
+  max_retries = 4
+
+}
+
+resource "site24x7_schedule_report" "weekly_summary" {
+  # Display name for the scheduled report
+  display_name = "Schedule Summary Report"
+
+  # Report type constant
+  # 17 = Summary Report
+  report_type = 17
+
+  # Resource selection type
+  # 0 = All Monitors
+  # 2 = Specific Monitors
+  # 3 = Tags
+  # 4 = Monitor Type
+  selection_type = 0
+
+  # Report output format
+  # 1 = PDF
+  # 2 = CSV
+  report_format = 2
+
+  # Report frequency
+  # 1 = Daily
+  # 2 = Weekly
+  # 3 = Monthly
+  report_frequency = 2
+
+  # Day of the week the report is generated
+  # 1 = Sunday, 2 = Monday, ... 7 = Saturday
+  scheduled_day = 3
+
+  # Hour of the day the report is generated (0–23)
+  scheduled_time = 10
+
+  # List of user group IDs who will receive the report
+  user_groups = [4111500000000]
+}

--- a/site24x7/monitors/azure.go
+++ b/site24x7/monitors/azure.go
@@ -1,6 +1,7 @@
 package monitors
 
 import (
+	"encoding/json"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -74,43 +75,41 @@ var AzureMonitorSchema = map[string]*schema.Schema{
 		Description: "Automatically add newly-added subscriptions (1 for Yes, 0 for No).",
 	},
 	"azure_exclude_tags": {
-		Type:        schema.TypeMap,
+		Type:        schema.TypeList,
 		Optional:    true,
+		MaxItems:    1,
 		Description: "Tags to exclude Azure resources from discovery.",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"type": {
-					Type:     schema.TypeInt,
-					Required: true,
+					Type:        schema.TypeInt,
+					Required:    true,
+					Description: "Condition logic: 1 for OR, 2 for AND.",
 				},
 				"tags": {
-					Type:     schema.TypeMap,
-					Required: true,
-					Elem: &schema.Schema{
-						Type: schema.TypeList,
-						Elem: &schema.Schema{Type: schema.TypeString},
-					},
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "JSON-encoded map of tag keys to value lists, e.g. {\"demo\":[\"test1\",\"test2\"]}.",
 				},
 			},
 		},
 	},
 	"azure_include_tags": {
-		Type:        schema.TypeMap,
+		Type:        schema.TypeList,
 		Optional:    true,
+		MaxItems:    1,
 		Description: "Tags to include Azure resources in discovery.",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"type": {
-					Type:     schema.TypeInt,
-					Required: true,
+					Type:        schema.TypeInt,
+					Required:    true,
+					Description: "Condition logic: 1 for OR, 2 for AND.",
 				},
 				"tags": {
-					Type:     schema.TypeMap,
-					Required: true,
-					Elem: &schema.Schema{
-						Type: schema.TypeList,
-						Elem: &schema.Schema{Type: schema.TypeString},
-					},
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "JSON-encoded map of tag keys to value lists, e.g. {\"env\":[\"prod\"]}.",
 				},
 			},
 		},
@@ -186,70 +185,47 @@ func azureMonitorExists(d *schema.ResourceData, meta interface{}) (bool, error) 
 	return err == nil, err
 }
 
-func expandAzureTagCondition(input map[string]interface{}) *api.AzureTagCondition {
-	if input == nil {
+func expandAzureTagCondition(input []interface{}) *api.AzureTagCondition {
+	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
 
-	// Guard against missing or nil values
-	typeVal, typeOk := input["type"]
-	tagsVal, tagsOk := input["tags"]
-
-	if !typeOk || !tagsOk {
-		return nil // or handle the error appropriately
-	}
-
-	// Ensure type is an int
-	typeInt, ok := typeVal.(int)
-	if !ok {
-		// Log error or handle the unexpected type
-		return nil // or return an error if necessary
-	}
+	raw := input[0].(map[string]interface{})
 
 	tagCondition := &api.AzureTagCondition{
-		Type: typeInt,
+		Type: raw["type"].(int),
 		Tags: make(map[string][]string),
 	}
 
-	// Check if 'tags' is of the correct type
-	rawTags, ok := tagsVal.(map[string]interface{})
-	if !ok {
-		// Handle the unexpected type
-		return tagCondition // or handle accordingly
-	}
-
-	for k, v := range rawTags {
-		interfaceList, ok := v.([]interface{})
-		if !ok {
-			continue // or handle the invalid type
+	tagsJSON := raw["tags"].(string)
+	if tagsJSON != "" {
+		var tagsMap map[string][]string
+		if err := json.Unmarshal([]byte(tagsJSON), &tagsMap); err != nil {
+			log.Printf("[ERROR] Failed to unmarshal azure tags: %s", err)
+			return tagCondition
 		}
-		strList := make([]string, len(interfaceList))
-		for i, val := range interfaceList {
-			strList[i] = val.(string)
-		}
-		tagCondition.Tags[k] = strList
+		tagCondition.Tags = tagsMap
 	}
 
 	return tagCondition
 }
 
-func flattenAzureTagCondition(condition *api.AzureTagCondition) map[string]interface{} {
+func flattenAzureTagCondition(condition *api.AzureTagCondition) []interface{} {
 	if condition == nil {
 		return nil
 	}
 
-	tags := make(map[string]interface{})
-	for k, v := range condition.Tags {
-		strList := make([]interface{}, len(v))
-		for i, s := range v {
-			strList[i] = s
-		}
-		tags[k] = strList
+	tagsJSON, err := json.Marshal(condition.Tags)
+	if err != nil {
+		log.Printf("[ERROR] Failed to marshal azure tags: %s", err)
+		return nil
 	}
 
-	return map[string]interface{}{
-		"type": condition.Type,
-		"tags": tags,
+	return []interface{}{
+		map[string]interface{}{
+			"type": condition.Type,
+			"tags": string(tagsJSON),
+		},
 	}
 }
 
@@ -282,8 +258,8 @@ func resourceDataToAzureMonitor(d *schema.ResourceData, client site24x7.Client) 
 		ThresholdProfileID:    d.Get("threshold_profile_id").(string),
 		DiscoveryInterval:     d.Get("discovery_interval").(string),
 		AutoAddSubscription:   d.Get("auto_add_subscription").(int),
-		AzureExcludeTags:      expandAzureTagCondition(d.Get("azure_exclude_tags").(map[string]interface{})),
-		AzureIncludeTags:      expandAzureTagCondition(d.Get("azure_include_tags").(map[string]interface{})),
+		AzureExcludeTags:      expandAzureTagCondition(d.Get("azure_exclude_tags").([]interface{})),
+		AzureIncludeTags:      expandAzureTagCondition(d.Get("azure_include_tags").([]interface{})),
 	}
 	return monitor, nil
 }


### PR DESCRIPTION
This pull request introduces support for scheduled summary reports and refactors Azure tag handling in the Site24x7 Terraform provider. The main improvements are the addition of scheduled report resources and examples, and a significant update to the Azure monitor schema and tag condition serialization logic to handle Site24x7's API quirks.

**Scheduled Report Support:**

* Added documentation for the new `site24x7_schedule_report` resource in `README.md`, linking to API docs and an example file.
* Introduced a new Terraform example, `schedule_summary_report_eu.tf`, demonstrating how to configure a weekly summary report.

**Azure Monitor Tag Handling Refactor:**

* Changed `azure_exclude_tags` and `azure_include_tags` schema from `TypeMap` to `TypeList` with a single item, and updated their internal structure to use a JSON-encoded string for tags, matching Site24x7 API requirements.
* Refactored the expansion and flattening functions for Azure tag conditions to support the new schema and JSON serialization/deserialization. [[1]](diffhunk://#diff-0cbc8266955462ab413ced0c20104a6b18a559e3c14cb497c6268171e3ad4751L189-R228) [[2]](diffhunk://#diff-0cbc8266955462ab413ced0c20104a6b18a559e3c14cb497c6268171e3ad4751L285-R262)
* Added a custom `UnmarshalJSON` implementation for the `AzureTagCondition` struct to robustly handle both direct JSON objects and string-wrapped JSON returned by the Site24x7 API.

**General Improvements:**

* Updated imports in relevant files to support new JSON handling. [[1]](diffhunk://#diff-48dba37a89bbad21af6c4d8b66fd20583aadfca584594b57793cdd14f4d6330fR3-R7) [[2]](diffhunk://#diff-0cbc8266955462ab413ced0c20104a6b18a559e3c14cb497c6268171e3ad4751R4)